### PR TITLE
Eperez letter proofing

### DIFF
--- a/src/eduid_webapp/letter_proofing/helpers.py
+++ b/src/eduid_webapp/letter_proofing/helpers.py
@@ -36,6 +36,8 @@ def check_state(state):
             return {
                 'letter_sent': sent_dt,
                 'letter_expires': sent_dt + max_wait,
+                'letter_expired': False,
+                'message': 'letter.already-sent',
             }
         else:
             # If the letter haven't reached the user within the allotted time
@@ -44,10 +46,13 @@ def check_state(state):
             current_app.proofing_statedb.remove_document({'eduPersonPrincipalName': state.eppn})
             current_app.logger.info('Removed {!s}'.format(state))
             return {
+                'letter_sent': sent_dt,
+                'letter_expires': sent_dt + max_wait,
                 'letter_expired': True,
+                'message': 'letter.expired',
             }
     current_app.logger.info('Unfinished state for user with eppn {!s}'.format(state.eppn))
-    return {}
+    return {'message': 'letter.not-sent'}
 
 
 def create_proofing_state(eppn, nin):

--- a/src/eduid_webapp/letter_proofing/tests/test_app.py
+++ b/src/eduid_webapp/letter_proofing/tests/test_app.py
@@ -191,7 +191,8 @@ class LetterProofingTests(EduidAPITestCase):
         self.app.config.update({'LETTER_WAIT_TIME_HOURS': -24})
         json_data = self.get_state()
         self.assertTrue(json_data['payload']['letter_expired'])
-        self.assertNotIn('letter_sent', json_data['payload'])
+        self.assertIn('letter_sent', json_data['payload'])
+        self.assertIsNotNone(json_data['payload']['letter_sent'])
 
     @patch('eduid_common.api.msg.MsgRelay.get_postal_address')
     def test_unmarshal_error(self, mock_get_postal_address):

--- a/src/eduid_webapp/letter_proofing/views.py
+++ b/src/eduid_webapp/letter_proofing/views.py
@@ -48,15 +48,14 @@ def proofing(user, nin):
         current_app.logger.info('Created proofing state for user {}'.format(user))
 
     if proofing_state.proofing_letter.is_sent:
-        current_app.logger.info('A letter has already been sent to User {!r}. '
-                                'This is the proofing state: '
-                                '{!r}'.format(user, proofing_state.to_dict()))
+        current_app.logger.info('A letter has already been sent to the user. ')
+        current_app.logger.debug('Proofing state: {}'.format(proofing_state.to_dict()))
         result = check_state(proofing_state)
         if not result['letter_expired']:
             return result
         else:
-            current_app.logger.info('The letter sent to User {!r} has already '
-                                'expired. Sending a new one...'.format(user))
+            # XXX Are we sure that the user wants to send a new letter?
+            current_app.logger.info('The letter has expired. Sending a new one...')
     try:
         address = get_address(user, proofing_state)
         if not address:

--- a/src/eduid_webapp/letter_proofing/views.py
+++ b/src/eduid_webapp/letter_proofing/views.py
@@ -48,12 +48,15 @@ def proofing(user, nin):
         current_app.logger.info('Created proofing state for user {}'.format(user))
 
     if proofing_state.proofing_letter.is_sent:
-        current_app.logger.info('User {!r} has already sent a letter'.format(user))
-        current_app.logger.info('This is the proofing state: '
-                                '{!r}'.format(proofing_state.to_dict()))
+        current_app.logger.info('A letter has already been sent to User {!r}. '
+                                'This is the proofing state: '
+                                '{!r}'.format(user, proofing_state.to_dict()))
         result = check_state(proofing_state)
-        result['message'] = 'letter.already-sent'
-
+        if not result['letter_expired']:
+            return result
+        else:
+            current_app.logger.info('The letter sent to User {!r} has already '
+                                'expired. Sending a new one...'.format(user))
     try:
         address = get_address(user, proofing_state)
         if not address:


### PR DESCRIPTION
This is mostly cosmetic except for the added line 55 in src/eduid_webapp/letter_proofing/views.py, `return result` which is needed I think