### PR TITLE
Eperez eppn authn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 import sys
 
-version = '0.2.2b2'
+version = '0.2.2b3'
 
 # Use requirements files
 requires = [

--- a/src/eduid_webapp/actions/tests/test_app.py
+++ b/src/eduid_webapp/actions/tests/test_app.py
@@ -54,6 +54,8 @@ class ActionsTests(ActionsTestCase):
         config['TOKEN_LOGIN_SHARED_KEY'] = config['TOKEN_LOGIN_SHARED_KEY'][:nacl.secret.SecretBox.KEY_SIZE]
         if len(config['TOKEN_LOGIN_SHARED_KEY']) < 32:
             config['TOKEN_LOGIN_SHARED_KEY'] += (32 - len(config['TOKEN_LOGIN_SHARED_KEY'])) * '0'
+        if not isinstance(config['TOKEN_LOGIN_SHARED_KEY'], six.binary_type):
+            config['TOKEN_LOGIN_SHARED_KEY'] = config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         self.assertEqual(32, len(config['TOKEN_LOGIN_SHARED_KEY']))
         return config
 

--- a/src/eduid_webapp/actions/tests/test_app.py
+++ b/src/eduid_webapp/actions/tests/test_app.py
@@ -122,11 +122,11 @@ class ActionsTests(ActionsTestCase):
         with self.session_cookie(self.browser) as client:
             with client.session_transaction() as sess:
                 with self.app.test_request_context():
-                    eppn = 'dummy-eppn'
+                    eppn = b'dummy-eppn'
                     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
                     timestamp = str(hex(int(time.time())))
                     shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY']
-                    token_data = '{0}|{1}'.format(timestamp, eppn)
+                    token_data = b'{0}|{1}'.format(timestamp, eppn)
                     box = nacl.secret.SecretBox(shared_key)
                     encrypted = box.encrypt(token_data, nonce)
                     if six.PY2:

--- a/src/eduid_webapp/actions/tests/test_app.py
+++ b/src/eduid_webapp/actions/tests/test_app.py
@@ -50,6 +50,13 @@ except ImportError:
 
 class ActionsTests(ActionsTestCase):
 
+    def update_actions_config(self, config):
+        config['TOKEN_LOGIN_SHARED_KEY'] = config['TOKEN_LOGIN_SHARED_KEY'][:nacl.secret.SecretBox.KEY_SIZE]
+        if len(config['TOKEN_LOGIN_SHARED_KEY']) < 32:
+            config['TOKEN_LOGIN_SHARED_KEY'] += (32 - len(config['TOKEN_LOGIN_SHARED_KEY'])) * '0'
+        self.assertEqual(32, len(config['TOKEN_LOGIN_SHARED_KEY']))
+        return config
+
     @unittest.skipUnless(NEW_ACTIONS, "Still using old actions")
     def test_authn_no_data(self):
         response = self.browser.get('/')

--- a/src/eduid_webapp/actions/tests/test_app.py
+++ b/src/eduid_webapp/actions/tests/test_app.py
@@ -122,11 +122,11 @@ class ActionsTests(ActionsTestCase):
         with self.session_cookie(self.browser) as client:
             with client.session_transaction() as sess:
                 with self.app.test_request_context():
-                    eppn = b'dummy-eppn'
+                    eppn = 'dummy-eppn'
                     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
                     timestamp = str(hex(int(time.time())))
                     shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY']
-                    token_data = b'{0}|{1}'.format(timestamp, eppn)
+                    token_data = '{0}|{1}'.format(timestamp, eppn).encode('ascii')
                     box = nacl.secret.SecretBox(shared_key)
                     encrypted = box.encrypt(token_data, nonce)
                     if six.PY2:

--- a/src/eduid_webapp/actions/views.py
+++ b/src/eduid_webapp/actions/views.py
@@ -51,27 +51,32 @@ def authn():
     '''
     '''
     userid = request.args.get('userid', None)
+    eppn = request.args.get('eppn', None)
+    eppn = userid or eppn
     token = request.args.get('token', None)
     nonce = request.args.get('nonce', None)
     timestamp = request.args.get('ts', None)
     idp_session = request.args.get('session', None)
-    if not (userid and token and nonce and timestamp):
+    if not (eppn and token and nonce and timestamp):
         msg = ('Insufficient authentication params: '
-               'userid: {}, token: {}, nonce: {}, ts: {}')
-        current_app.logger.debug(msg.format(userid, token, nonce, timestamp))
+               'eppn: {}, token: {}, nonce: {}, ts: {}')
+        current_app.logger.debug(msg.format(eppn, token, nonce, timestamp))
         abort(400)
 
-    if verify_auth_token(eppn=userid, token=token,
+    if verify_auth_token(eppn=eppn, token=token,
                          nonce=nonce, timestamp=timestamp):
         current_app.logger.info("Starting pre-login actions "
-                                "for userid: {})".format(userid))
-        session['userid'] = userid
+                                "for eppn: {})".format(eppn))
+        if userid is not None:
+            session['userid'] = userid
+        else:
+            session['user_eppn'] = eppn
         session['idp_session'] = idp_session
         url = url_for('actions.get_actions')
         return render_template('index.html', url=url)
     else:
         current_app.logger.debug("Token authentication failed "
-                                 "(userid: {})".format(userid))
+                                 "(eppn: {})".format(eppn))
         abort(403)
 
 
@@ -108,9 +113,9 @@ def get_actions():
     action_type = session['current_plugin']
     plugin_obj = current_app.plugins[action_type]()
     action = Action(data=session['current_action'])
+    eppn = 'userid' in session and session['userid'] or session['user_eppn']
     current_app.logger.info('Starting pre-login action {} '
-                            'for userid {}'.format(action.action_type,
-                                                    session['userid']))
+                            'for eppn {}'.format(action.action_type, eppn))
     try:
         url = plugin_obj.get_url_for_bundle(action)
         return json.dumps({'action': True,
@@ -155,10 +160,10 @@ def post_action():
                 'csrf_token': session.new_csrf_token()
                 }
 
+    eppn = 'userid' in session and session['userid'] or session['user_eppn']
     if session['total_steps'] == session['current_step']:
         current_app.logger.info('Finished pre-login action {0} '
-                                'for userid {1}'.format(action.action_type,
-                                                        session['userid']))
+                                'for eppn {1}'.format(action.action_type, eppn))
         return {
                 'message': 'actions.action-completed',
                 'data': data,
@@ -166,9 +171,9 @@ def post_action():
                 }
 
     current_app.logger.info('Performed step {} for action {} '
-                            'for userid {}'.format(action.action_type,
+                            'for eppn {}'.format(action.action_type,
                                                     session['current_step'],
-                                                    session['userid']))
+                                                    eppn))
     session['current_step'] += 1
 
     return {
@@ -178,10 +183,10 @@ def post_action():
 
 
 def _aborted(action, exc):
-    current_app.logger.info(u'Aborted pre-login action {} for userid {}, '
+    eppn = 'userid' in session and session['userid'] or session['user_eppn']
+    current_app.logger.info(u'Aborted pre-login action {} for eppn {}, '
                             u'reason: {}'.format(action.action_type,
-                                                 session['userid'],
-                                                 exc.args[0]))
+                                                 eppn, exc.args[0]))
     if exc.remove_action:
         aid = action.action_id
         msg = 'Removing faulty action with id '

--- a/src/eduid_webapp/actions/views.py
+++ b/src/eduid_webapp/actions/views.py
@@ -88,7 +88,7 @@ def get_config():
     except KeyError:
         abort(403)
     plugin_obj = current_app.plugins[action_type]()
-    action = Action(data=session['current_action'])
+    action = Action(data=session['current_action'], old_format=True)
     try:
         config = plugin_obj.get_config_for_bundle(action)
         config['csrf_token'] = session.new_csrf_token()
@@ -112,7 +112,7 @@ def get_actions():
                            })
     action_type = session['current_plugin']
     plugin_obj = current_app.plugins[action_type]()
-    action = Action(data=session['current_action'])
+    action = Action(data=session['current_action'], old_format=True)
     eppn = 'userid' in session and session['userid'] or session['user_eppn']
     current_app.logger.info('Starting pre-login action {} '
                             'for eppn {}'.format(action.action_type, eppn))
@@ -139,7 +139,7 @@ def post_action():
     except KeyError:
         abort(403)
     plugin_obj = current_app.plugins[action_type]()
-    action = Action(data=session['current_action'])
+    action = Action(data=session['current_action'], old_format=True)
     errors = {}
     try:
         data = plugin_obj.perform_step(action)

--- a/src/eduid_webapp/authn/helpers.py
+++ b/src/eduid_webapp/authn/helpers.py
@@ -48,7 +48,7 @@ def verify_auth_token(eppn, token, nonce, timestamp, generator=sha256):
     # try to open secret box
     try:
         box = nacl.secret.SecretBox(shared_key)
-        encrypted = token.decode('hex')
+        encrypted = token
         plaintext = box.decrypt(encrypted)
         return plaintext == '{}|{}'.format(timestamp, eppn)
     except (LookupError, nacl.exceptions.CryptoError) as e:

--- a/src/eduid_webapp/authn/helpers.py
+++ b/src/eduid_webapp/authn/helpers.py
@@ -52,13 +52,13 @@ def verify_auth_token(eppn, token, nonce, timestamp, generator=sha256):
         if six.PY2:
             encrypted = token.encode('ascii').decode('hex')
         else:
-            encrypted = token.encode('ascii').hex()
+            encrypted = token.encode('ascii').fromhex(token)
     else:
         encrypted = token.decode('hex')
     try:
         box = nacl.secret.SecretBox(secret_key)
         plaintext = box.decrypt(encrypted)
-        return plaintext == '{}|{}'.format(timestamp, eppn)
+        return plaintext == '{}|{}'.format(timestamp, eppn).encode('ascii')
     except (LookupError, nacl.exceptions.CryptoError) as e:
         current_app.logger.debug('Secretbox decryption failed, error: ' + str(e))
 

--- a/src/eduid_webapp/authn/helpers.py
+++ b/src/eduid_webapp/authn/helpers.py
@@ -48,7 +48,9 @@ def verify_auth_token(eppn, token, nonce, timestamp, generator=sha256):
     # try to open secret box
     encrypted = token
     if isinstance(token, six.text_type):
-        encrypted = token.encode('ascii')
+        encrypted = token.encode('ascii').decode('hex')
+    else:
+        encrypted = token.decode('hex')
     try:
         box = nacl.secret.SecretBox(shared_key)
         plaintext = box.decrypt(encrypted)

--- a/src/eduid_webapp/authn/helpers.py
+++ b/src/eduid_webapp/authn/helpers.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import time
+import six
 from flask import current_app
 from hashlib import sha256
 try:
@@ -33,6 +34,8 @@ def verify_auth_token(eppn, token, nonce, timestamp, generator=sha256):
     """
     current_app.logger.debug('Trying to authenticate user {} with auth token {}'.format(eppn, token))
     shared_key = current_app.config.get('TOKEN_LOGIN_SHARED_KEY')
+    if not isinstance(shared_key, six.binary_type):
+        shared_key = shared_key.encode('ascii')
 
     # check timestamp to make sure it is within -300..900 seconds from now
     now = int(time.time())

--- a/src/eduid_webapp/authn/helpers.py
+++ b/src/eduid_webapp/authn/helpers.py
@@ -46,9 +46,11 @@ def verify_auth_token(eppn, token, nonce, timestamp, generator=sha256):
         return False
 
     # try to open secret box
+    encrypted = token
+    if isinstance(token, six.text_type):
+        encrypted = token.encode('ascii')
     try:
         box = nacl.secret.SecretBox(shared_key)
-        encrypted = token
         plaintext = box.decrypt(encrypted)
         return plaintext == '{}|{}'.format(timestamp, eppn)
     except (LookupError, nacl.exceptions.CryptoError) as e:

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -344,7 +344,7 @@ class AuthnAPITestCase(AuthnAPITestBase):
 
         data = {
             'eppn': eppn,
-            'token': token,
+            'token': hex_token,
             'nonce': nonce,
             'ts': timestamp
         }

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -329,23 +329,21 @@ class AuthnAPITestCase(AuthnAPITestBase):
 
     def test_token_login_new_user_secret_box(self):
         eppn = 'hubba-fooo'
-        shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY']
+        shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
-        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
+        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE).encode('ascii')
         token_data = '{0}|{1}'.format(timestamp, eppn)
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)
         if six.PY2:
             token = encrypted.encode('hex')
-            hex_nonce = nonce.encode('hex')
         else:
             token = encrypted.hex()
-            hex_nonce = nonce.hex()
 
         data = {
             'eppn': eppn,
             'token': token,
-            'nonce': hex_nonce,
+            'nonce': nonce,
             'ts': timestamp
         }
 
@@ -380,9 +378,9 @@ class AuthnAPITestCase(AuthnAPITestBase):
 
     def test_token_login_old_user_secret_box(self):
         eppn = 'hubba-bubba'
-        shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY']
+        shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
-        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
+        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE).encode('ascii')
         token_data = '{0}|{1}'.format(timestamp, eppn)
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -331,7 +331,7 @@ class AuthnAPITestCase(AuthnAPITestBase):
         eppn = 'hubba-fooo'
         shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
-        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE).encode('ascii')
+        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
         token_data = '{0}|{1}'.format(timestamp, eppn)
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)
@@ -380,7 +380,7 @@ class AuthnAPITestCase(AuthnAPITestBase):
         eppn = 'hubba-bubba'
         shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
-        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE).encode('ascii')
+        nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
         token_data = '{0}|{1}'.format(timestamp, eppn)
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -328,11 +328,11 @@ class AuthnAPITestCase(AuthnAPITestBase):
             self.assertTrue(resp.location.startswith(self.app.config['TOKEN_LOGIN_SUCCESS_REDIRECT_URL']))
 
     def test_token_login_new_user_secret_box(self):
-        eppn = b'hubba-fooo'
+        eppn = 'hubba-fooo'
         shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-        token_data = b'{0}|{1}'.format(timestamp, eppn)
+        token_data = '{0}|{1}'.format(timestamp, eppn).encode('ascii')
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)
         if six.PY2:
@@ -377,11 +377,11 @@ class AuthnAPITestCase(AuthnAPITestBase):
             self.assertTrue(resp.location.startswith(self.app.config['TOKEN_LOGIN_FAILURE_REDIRECT_URL']))
 
     def test_token_login_old_user_secret_box(self):
-        eppn = b'hubba-bubba'
+        eppn = 'hubba-bubba'
         shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-        token_data = b'{0}|{1}'.format(timestamp, eppn)
+        token_data = '{0}|{1}'.format(timestamp, eppn).encode('ascii')
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)
         if six.PY2:

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -344,8 +344,8 @@ class AuthnAPITestCase(AuthnAPITestBase):
 
         data = {
             'eppn': eppn,
-            'token': hex_token,
-            'nonce': nonce,
+            'token': token,
+            'nonce': hex_nonce,
             'ts': timestamp
         }
 

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -328,11 +328,11 @@ class AuthnAPITestCase(AuthnAPITestBase):
             self.assertTrue(resp.location.startswith(self.app.config['TOKEN_LOGIN_SUCCESS_REDIRECT_URL']))
 
     def test_token_login_new_user_secret_box(self):
-        eppn = 'hubba-fooo'
+        eppn = b'hubba-fooo'
         shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-        token_data = '{0}|{1}'.format(timestamp, eppn)
+        token_data = b'{0}|{1}'.format(timestamp, eppn)
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)
         if six.PY2:
@@ -377,11 +377,11 @@ class AuthnAPITestCase(AuthnAPITestBase):
             self.assertTrue(resp.location.startswith(self.app.config['TOKEN_LOGIN_FAILURE_REDIRECT_URL']))
 
     def test_token_login_old_user_secret_box(self):
-        eppn = 'hubba-bubba'
+        eppn = b'hubba-bubba'
         shared_key = self.app.config['TOKEN_LOGIN_SHARED_KEY'].encode('ascii')
         timestamp = '{:x}'.format(int(time.time()))
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-        token_data = '{0}|{1}'.format(timestamp, eppn)
+        token_data = b'{0}|{1}'.format(timestamp, eppn)
         box = nacl.secret.SecretBox(shared_key)
         encrypted = box.encrypt(token_data, nonce)
         if six.PY2:

--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -337,8 +337,10 @@ class AuthnAPITestCase(AuthnAPITestBase):
         encrypted = box.encrypt(token_data, nonce)
         if six.PY2:
             token = encrypted.encode('hex')
+            hex_nonce = nonce.encode('hex')
         else:
             token = encrypted.hex()
+            hex_nonce = nonce.hex()
 
         data = {
             'eppn': eppn,

--- a/src/eduid_webapp/security/helpers.py
+++ b/src/eduid_webapp/security/helpers.py
@@ -36,6 +36,9 @@ def compile_credential_list(security_user):
     credentials = []
     authn_info = current_app.authninfo_db.get_authn_info(security_user)
     credentials_used = session.get('eduidIdPCredentialsUsed', list())
+    # In the development environment credentials_used gets set to None
+    if credentials_used is None:
+        credentials_used = []
     for credential in security_user.credentials.to_list():
         credential_dict = credential.to_dict()
         credential_dict['key'] = credential.key

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -173,7 +173,7 @@ def complete_registration(signup_user):
         shared_key = shared_key.encode('ascii')
     timestamp = '{:x}'.format(int(time.time()))
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-    token_data = b'{0}|{1}'.format(timestamp, eppn)
+    token_data = '{0}|{1}'.format(timestamp, eppn).encode('ascii')
     box = nacl.secret.SecretBox(shared_key)
     encrypted = box.encrypt(token_data, nonce)
     if six.PY2:

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -172,9 +172,7 @@ def complete_registration(signup_user):
     timestamp = '{:x}'.format(int(time.time()))
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
     token_data = '{0}|{1}'.format(timestamp, eppn)
-    try:
-        box = nacl.secret.SecretBox(shared_key)
-    except
+    box = nacl.secret.SecretBox(shared_key)
     encrypted = box.encrypt(token_data, nonce)
     if six.PY2:
         auth_token = encrypted.encode('hex')

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -175,7 +175,7 @@ def complete_registration(signup_user):
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
     token_data = '{0}|{1}'.format(timestamp, eppn)
     box = nacl.secret.SecretBox(shared_key)
-    encrypted = box.encrypt(token_data, nonce.encode('ascii'))
+    encrypted = box.encrypt(token_data, nonce)
     if six.PY2:
         auth_token = encrypted.encode('hex')
         hex_nonce = nonce.encode('hex')

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -169,6 +169,8 @@ def complete_registration(signup_user):
 
     eppn = signup_user.eppn
     shared_key = current_app.config.get('AUTH_SHARED_SECRET')
+    if not isinstance(shared_key, six.binary_type):
+        shared_key = shared_key.encode('ascii')
     timestamp = '{:x}'.format(int(time.time()))
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
     token_data = '{0}|{1}'.format(timestamp, eppn)

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -173,7 +173,7 @@ def complete_registration(signup_user):
         shared_key = shared_key.encode('ascii')
     timestamp = '{:x}'.format(int(time.time()))
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-    token_data = '{0}|{1}'.format(timestamp, eppn)
+    token_data = b'{0}|{1}'.format(timestamp, eppn)
     box = nacl.secret.SecretBox(shared_key)
     encrypted = box.encrypt(token_data, nonce)
     if six.PY2:

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -40,6 +40,8 @@ from hashlib import sha256
 from bson import ObjectId
 import proquint
 
+import nacl.utils
+import nacl.secret
 from flask import current_app, abort
 
 from eduid_common.api.utils import save_and_sync_user
@@ -165,20 +167,27 @@ def complete_registration(signup_user):
             'message': 'user-out-of-sync'
         }
 
-    secret = current_app.config.get('AUTH_SHARED_SECRET')
+
+    eppn = signup_user.eppn
+    shared_key = current_app.config.get('AUTH_SHARED_SECRET')
     timestamp = '{:x}'.format(int(time.time()))
+    nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
+    token_data = '{0}|{1}'.format(timestamp, eppn)
+    box = nacl.secret.SecretBox(shared_key)
+    encrypted = box.encrypt(token_data, nonce)
     if six.PY2:
-        nonce = os.urandom(16).encode('hex')
+        auth_token = encrypted.encode('hex')
+        hex_nonce = nonce.encode('hex')
     else:
-        nonce = os.urandom(16).hex()
-    auth_token = generate_auth_token(secret, signup_user.eppn, nonce, timestamp)
+        auth_token = encrypted.hex()
+        hex_nonce = nonce.hex()
 
     context.update({
         "status": 'verified',
         "password": password,
         "email": signup_user.mail_addresses.primary.email,
         "eppn": signup_user.eppn,
-        "nonce": nonce,
+        "nonce": hex_nonce,
         "timestamp": timestamp,
         "auth_token": auth_token,
         "dashboard_url": current_app.config.get('AUTH_TOKEN_URL')
@@ -212,29 +221,3 @@ def record_tou(user, source):
         created_ts = created_ts,
         event_id = event_id
         ))
-
-
-def generate_auth_token(shared_key, email, nonce, timestamp, generator=sha256):
-    """
-    Generate authn token for the dashboard.
-    The shared_key is a secret shared with the dashboard app.
-
-    :param shared_key: the secret
-    :type shared_key: str
-    :param email: the email of the user to be authn
-    :type email: str
-    :param nonce: the nonce
-    :type nonce: str
-    :param timestamp: a timestamp
-    :type timestamp: str
-    :param generator: the hash function
-    :type generator: function
-
-    :return: the authn token
-    :rtype: str
-    """
-    current_app.logger.debug("Generating auth-token for user {}, "
-                        "nonce {}, ts {!r}".format(email, nonce, timestamp))
-    data = "{0}|{1}|{2}|{3}".format(shared_key, email, nonce, timestamp)
-    hashed = generator(data.encode('utf-8'))
-    return hashed.hexdigest()

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -175,7 +175,7 @@ def complete_registration(signup_user):
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
     token_data = '{0}|{1}'.format(timestamp, eppn)
     box = nacl.secret.SecretBox(shared_key)
-    encrypted = box.encrypt(token_data, nonce)
+    encrypted = box.encrypt(token_data, nonce.encode('ascii'))
     if six.PY2:
         auth_token = encrypted.encode('hex')
         hex_nonce = nonce.encode('hex')

--- a/src/eduid_webapp/signup/helpers.py
+++ b/src/eduid_webapp/signup/helpers.py
@@ -167,13 +167,14 @@ def complete_registration(signup_user):
             'message': 'user-out-of-sync'
         }
 
-
     eppn = signup_user.eppn
     shared_key = current_app.config.get('AUTH_SHARED_SECRET')
     timestamp = '{:x}'.format(int(time.time()))
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
     token_data = '{0}|{1}'.format(timestamp, eppn)
-    box = nacl.secret.SecretBox(shared_key)
+    try:
+        box = nacl.secret.SecretBox(shared_key)
+    except
     encrypted = box.encrypt(token_data, nonce)
     if six.PY2:
         auth_token = encrypted.encode('hex')

--- a/src/eduid_webapp/signup/tests/test_app.py
+++ b/src/eduid_webapp/signup/tests/test_app.py
@@ -62,7 +62,7 @@ class SignupTests(EduidAPITestCase):
             'PASSWORD_LENGTH': '10',
             'VCCS_URL': 'http://turq:13085/',
             'TOU_VERSION': '2018-v1',
-            'AUTH_SHARED_SECRET': 'shared_secret_Eifool0ua0eiph7ooch0',
+            'AUTH_SHARED_SECRET': 'shared_secret_Eifool0ua0eiph7ooc',
             'DEFAULT_FINISH_URL': 'https://www.eduid.se/',
             'RECAPTCHA_PUBLIC_KEY': '',  # disable recaptcha verification
             'RECAPTCHA_PRIVATE_KEY': 'XXXX',


### PR DESCRIPTION
  * The actions2 app can understand login tokens from the IdP encrypted
    using hmac with either eppn or userid.
  * The actions2 and the authn apps can understand login tokens
    encrypted with either hmac or nacl's secret box.
