### PR TITLE
handle missing eduidIdPCredentialsUsed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.2.2b11'
+version = '0.2.2b12'
 
 # Use requirements files
 requires = [

--- a/src/eduid_webapp/eidas/views.py
+++ b/src/eduid_webapp/eidas/views.py
@@ -42,9 +42,9 @@ def verify_token(user, credential_id):
         new_query_string = urlencode({'msg': ':ERROR:eidas.token_not_found'})
         url = urlunsplit((scheme, netloc, path, new_query_string, fragment))
         return redirect(url)
-    if token_to_verify.key not in session['eduidIdPCredentialsUsed']:
+    if token_to_verify.key not in session.get('eduidIdPCredentialsUsed', []):
         # If token was not used for login, reauthn the user
-        current_app.logger.info('Token not used for login, redirecting to idp')
+        current_app.logger.info('Token {} not used for login, redirecting to idp'.format(token_to_verify.key))
         ts_url = current_app.config.get('TOKEN_SERVICE_URL')
         reauthn_url = urlappend(ts_url, 'reauthn')
         next_url = url_for('eidas.verify_token', credential_id=credential_id, _external=True)


### PR DESCRIPTION
When token-login was used to go from signup to dashboard, this attribute
won't be present in the session so default to an empty list.