### PR TITLE
Eperez platform webauthn

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,5 +16,4 @@ zxcvbn>=4.4.27,==4.*
 bleach>=2.1.4
 html5lib>=1.0.1
 idna>=2.1,<2.8
-fido2==0.5.0
 git+git://github.com/Yubico/python-fido2@2860264#egg=fido2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,3 +17,4 @@ bleach>=2.1.4
 html5lib>=1.0.1
 idna>=2.1,<2.8
 fido2==0.5.0
+git+git://github.com/Yubico/python-fido2@2860264#egg=fido2

--- a/src/eduid_webapp/security/schemas.py
+++ b/src/eduid_webapp/security/schemas.py
@@ -169,6 +169,10 @@ class WebauthnOptionsResponseSchema(FluxStandardAction):
     payload = fields.Nested(WebauthnOptionsResponsePayload)
 
 
+class WebauthnRegisterBeginSchema(EduidSchema, CSRFRequestMixin):
+
+    authenticator = fields.String(required=True)
+
 class WebauthnRegisterRequestSchema(EduidSchema, CSRFRequestMixin):
 
     credential_id = fields.String(required=True, load_from="credentialId")

--- a/src/eduid_webapp/security/views/webauthn.py
+++ b/src/eduid_webapp/security/views/webauthn.py
@@ -27,6 +27,7 @@ from eduid_common.api.utils import save_and_sync_user
 from eduid_common.api.schemas.base import FluxStandardAction
 from eduid_webapp.security.helpers import credentials_to_registered_keys, compile_credential_list
 from eduid_webapp.security.schemas import WebauthnOptionsResponseSchema, WebauthnRegisterRequestSchema
+from eduid_webapp.security.schemas import WebauthnRegisterBeginSchema
 from eduid_webapp.security.schemas import SecurityResponseSchema, RemoveWebauthnTokenRequestSchema
 from eduid_webapp.security.schemas import VerifyWithWebauthnTokenRequestSchema
 from eduid_webapp.security.schemas import VerifyWithWebauthnTokenResponseSchema
@@ -50,10 +51,11 @@ def make_credentials(creds):
 
 webauthn_views = Blueprint('webauthn', __name__, url_prefix='/webauthn', template_folder='templates')
 
-@webauthn_views.route('/register/begin', methods=['GET'])
+@webauthn_views.route('/register/begin', methods=['POST'])
+@UnmarshalWith(WebauthnRegisterBeginSchema)
 @MarshalWith(FluxStandardAction)
 @require_user
-def registration_begin(user):
+def registration_begin(user, authenticator):
     user_webauthn_tokens = user.credentials.filter(Webauthn)
     if user_webauthn_tokens.count >= current_app.config['WEBAUTHN_MAX_ALLOWED_TOKENS']:
         current_app.logger.error('User tried to register more than {} tokens.'.format(
@@ -67,7 +69,7 @@ def registration_begin(user):
         'id': str(user.eppn).encode('ascii'),
         'name': "{} {}".format(user.given_name, user.surname),
         'displayName': user.display_name
-    }, creds)
+    }, credentials=creds, authenticator_attachment=authenticator)
     session['_webauthn_state_'] = state
 
     current_app.logger.info('User {} has started registration of a webauthn token'.format(user))


### PR DESCRIPTION
This adds the possibility to choose which authenticator to register, either a portable key or an internal module in the actual device - only if there is such an internal module.