### PR TITLE
Eperez revisit chpass

### DIFF
--- a/src/eduid_webapp/authn/tests/test_authn.py
+++ b/src/eduid_webapp/authn/tests/test_authn.py
@@ -88,7 +88,7 @@ class AuthnAPITestBase(EduidAPITestCase):
         Called from the parent class, so we can provide the appropriate flask
         app for this test case.
         """
-        return authn_init_app('test.localhost', config)
+        return authn_init_app('testing', config)
 
     def add_outstanding_query(self, came_from):
         """

--- a/src/eduid_webapp/jsconfig/settings/front.py
+++ b/src/eduid_webapp/jsconfig/settings/front.py
@@ -59,6 +59,7 @@ class FrontConfig:
     # TODO: Remove after new design end
     static_faq_url: str = ''
     reset_passwd_url: str = ''
+    password_service_url: str = ''
     dashboard_url: str = ''
     personal_data_url: str = '/personal-data/user'
     emails_url: str = '/services/email/'

--- a/src/eduid_webapp/reset_password/app.py
+++ b/src/eduid_webapp/reset_password/app.py
@@ -40,7 +40,6 @@ from eduid_common.api.app import get_app_config
 from eduid_common.api import mail_relay
 from eduid_common.api import am, msg
 from eduid_common.api import mail_relay
-from eduid_common.api import translation
 from eduid_common.authn.middleware import AuthnBaseApp
 from eduid_common.authn.utils import no_authn_views
 from eduid_webapp.reset_password.settings.common import ResetPasswordConfig
@@ -56,16 +55,15 @@ class ResetPasswordApp(AuthnBaseApp):
 
         # Register views
         from eduid_webapp.reset_password.views.reset_password import reset_password_views
-        self.register_blueprint(reset_password_views, url_prefix=self.config.application_root)
+        self.register_blueprint(reset_password_views)
 
         # Register view path that should not be authorized
-        self = no_authn_views(self, ['/reset-password.*'])
+        self = no_authn_views(self, ['/reset.*'])
 
         # Init celery
         msg.init_relay(self)
         am.init_relay(self, 'eduid_reset_password')
         mail_relay.init_relay(self)
-        translation.init_babel(self)
 
         # Init dbs
         self.private_userdb = ResetPasswordUserDB(self.config.mongo_uri)
@@ -73,12 +71,7 @@ class ResetPasswordApp(AuthnBaseApp):
         self.proofing_log = ProofingLog(self.config.mongo_uri)
 
 
-def get_current_app() -> ResetPasswordApp:
-    """Teach pycharm about ResetPasswordApp"""
-    return current_app  # type: ignore
-
-
-current_reset_password_app = get_current_app()
+current_reset_password_app: ResetPasswordApp = cast(ResetPasswordApp, current_app)
 
 
 def init_reset_password_app(name: str, config: dict) -> ResetPasswordApp:

--- a/src/eduid_webapp/reset_password/app.py
+++ b/src/eduid_webapp/reset_password/app.py
@@ -60,7 +60,7 @@ class ResetPasswordApp(AuthnBaseApp):
         self.register_blueprint(reset_password_views)
 
         # Register view path that should not be authorized
-        self = no_authn_views(self, ['/reset.*'])
+        self = no_authn_views(self, [r'^(?!/chpass).*$'])
 
         # Init celery
         msg.init_relay(self)

--- a/src/eduid_webapp/reset_password/app.py
+++ b/src/eduid_webapp/reset_password/app.py
@@ -34,8 +34,10 @@
 from typing import cast
 from flask import current_app
 
+from eduid_userdb.authninfo import AuthnInfoDB
 from eduid_userdb.reset_password import ResetPasswordUserDB, ResetPasswordStateDB
 from eduid_userdb.logs import ProofingLog
+from eduid_common.api import translation
 from eduid_common.api.app import get_app_config
 from eduid_common.api import mail_relay
 from eduid_common.api import am, msg
@@ -66,11 +68,13 @@ class ResetPasswordApp(AuthnBaseApp):
         msg.init_relay(self)
         am.init_relay(self, 'eduid_reset_password')
         mail_relay.init_relay(self)
+        translation.init_babel(self)
 
         # Init dbs
         self.private_userdb = ResetPasswordUserDB(self.config.mongo_uri)
         self.password_reset_state_db = ResetPasswordStateDB(self.config.mongo_uri)
         self.proofing_log = ProofingLog(self.config.mongo_uri)
+        self.authninfo_db = AuthnInfoDB(self.config.mongo_uri)
 
 
 current_reset_password_app: ResetPasswordApp = cast(ResetPasswordApp, current_app)

--- a/src/eduid_webapp/reset_password/app.py
+++ b/src/eduid_webapp/reset_password/app.py
@@ -55,6 +55,8 @@ class ResetPasswordApp(AuthnBaseApp):
 
         # Register views
         from eduid_webapp.reset_password.views.reset_password import reset_password_views
+        from eduid_webapp.reset_password.views.change_password import change_password_views
+        self.register_blueprint(change_password_views)
         self.register_blueprint(reset_password_views)
 
         # Register view path that should not be authorized

--- a/src/eduid_webapp/reset_password/app.py
+++ b/src/eduid_webapp/reset_password/app.py
@@ -62,7 +62,7 @@ class ResetPasswordApp(AuthnBaseApp):
         self.register_blueprint(reset_password_views)
 
         # Register view path that should not be authorized
-        self = no_authn_views(self, [r'^(?!/chpass).*$'])
+        self = no_authn_views(self, [r'/reset.*'])
 
         # Init celery
         msg.init_relay(self)

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -36,7 +36,6 @@ from typing import Optional
 
 import bcrypt
 from flask import url_for
-from flask import session
 from flask import render_template
 from flask_babel import gettext as _
 
@@ -56,6 +55,7 @@ from eduid_common.api.utils import get_short_hash
 from eduid_common.api.helpers import send_mail
 from eduid_common.authn.utils import generate_password
 from eduid_common.authn.vccs import reset_password
+from eduid_common.session import session
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
 

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -226,10 +226,12 @@ def hash_password(password: str) -> str:
     return bcrypt.hashpw(password, bcrypt.gensalt())
 
 
-def check_password(password: str, hashed: str) -> bool:
+def check_password(password: str, hashed: Optional[str]) -> bool:
     """
     Check that the provided password corresponds to the provided hash
     """
+    if hashed is None:
+        return False
     password = ''.join(password.split())
     return bcrypt.checkpw(password, hashed)
 

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -31,13 +31,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import math
-import os
-from base64 import b64encode, b64decode
 from enum import Enum, unique
-from typing import Union, Optional, List
+from typing import Optional
 
 import bcrypt
 from flask import url_for
+from flask import session
 from flask import render_template
 from flask_babel import gettext as _
 
@@ -106,11 +105,11 @@ class ResetPwMsg(Enum):
     out_of_sync = 'user-out-of-sync'
 
 
-
 class BadCode(Exception):
     """
     Exception to signal that the password reset code received is not valid.
     """
+
     def __init__(self, msg: ResetPwMsg):
         self.msg = msg
 

--- a/src/eduid_webapp/reset_password/schemas.py
+++ b/src/eduid_webapp/reset_password/schemas.py
@@ -37,6 +37,7 @@ from flask_babel import gettext as _
 from marshmallow import fields, Schema, validates, validates_schema, validate, ValidationError
 
 from eduid_common.api.schemas.base import EduidSchema, FluxStandardAction
+from eduid_common.api.schemas.password import CredentialSchema
 from eduid_common.api.schemas.csrf import CSRFResponseMixin, CSRFRequestMixin
 from eduid_common.api.schemas.validators import validate_email
 

--- a/src/eduid_webapp/reset_password/schemas.py
+++ b/src/eduid_webapp/reset_password/schemas.py
@@ -37,9 +37,9 @@ from flask_babel import gettext as _
 from marshmallow import fields, Schema, validates, validates_schema, validate, ValidationError
 
 from eduid_common.api.schemas.base import EduidSchema, FluxStandardAction
-from eduid_common.api.schemas.password import CredentialSchema
 from eduid_common.api.schemas.csrf import CSRFResponseMixin, CSRFRequestMixin
 from eduid_common.api.schemas.validators import validate_email
+from eduid_webapp.security.schemas import CredentialSchema
 
 __author__ = 'eperez'
 

--- a/src/eduid_webapp/reset_password/schemas.py
+++ b/src/eduid_webapp/reset_password/schemas.py
@@ -106,5 +106,29 @@ class ResetPasswordWithCodeSchema(CSRFRequestMixin):
 
 
 class ResetPasswordWithPhoneCodeSchema(ResetPasswordWithCodeSchema):
-    
     phone_code = fields.String(required=True)
+
+
+class ChpassCredentialList(EduidSchema, CSRFResponseMixin):
+    credentials = fields.Nested(CredentialSchema, many=True)
+    next_url = fields.String(required=True)
+
+
+class ChpassResponseSchema(FluxStandardAction):
+    payload = fields.Nested(ChpassCredentialList)
+
+
+class ChangePasswordSchema(EduidSchema, CSRFRequestMixin):
+
+    old_password = fields.String(required=True)
+    new_password = fields.String(required=True)
+
+
+class SuggestedPassword(EduidSchema, CSRFResponseMixin):
+
+    suggested_password = fields.String(required=True)
+
+
+class SuggestedPasswordResponseSchema(FluxStandardAction):
+
+    payload = SuggestedPassword()

--- a/src/eduid_webapp/reset_password/settings/common.py
+++ b/src/eduid_webapp/reset_password/settings/common.py
@@ -57,3 +57,9 @@ class ResetPasswordConfig(FlaskConfig):
     # For number of rounds, it is recommended that a measurement is made to achieve
     # a cost of at least 100 ms on current hardware.
     password_generation_rounds: int = 2 ** 5
+    # timeout for phone verification token, in hours
+    phone_verification_timeout: int = 24
+    # timeout for reauthentication prior to changing password
+    chpass_timeout: int = 600
+    # VCCS URL
+    vccs_url: str = ''

--- a/src/eduid_webapp/reset_password/tests/test_app.py
+++ b/src/eduid_webapp/reset_password/tests/test_app.py
@@ -712,7 +712,7 @@ class ChangePasswordTests(EduidAPITestCase):
         self.assertEqual(response.status_code, 302)  # Redirect to token service
         with self.session_cookie(self.browser, eppn) as client:
 
-            response2 = client.get('/suggested-password')
+            response2 = client.get('/chpass/suggested-password')
 
             passwd = json.loads(response2.data)
             self.assertEqual(passwd['type'],
@@ -724,11 +724,11 @@ class ChangePasswordTests(EduidAPITestCase):
 
         eppn = self.test_user_data['eduPersonPrincipalName']
         with self.session_cookie(self.browser, eppn) as client:
-            response2 = client.post('/change-password')
+            response2 = client.post('/chpass/change-password')
 
             sec_data = json.loads(response2.data)
             self.assertEqual(sec_data['type'],
-                             "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                             "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
     def test_change_passwd_no_reauthn(self):
         eppn = self.test_user_data['eduPersonPrincipalName']
@@ -740,14 +740,14 @@ class ChangePasswordTests(EduidAPITestCase):
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                response2 = client.post('/change-password', data=json.dumps(data),
+                response2 = client.post('/chpass/change-password', data=json.dumps(data),
                                         content_type=self.content_type_json)
 
                 self.assertEqual(response2.status_code, 200)
 
                 sec_data = json.loads(response2.data)
                 self.assertEqual(sec_data['type'],
-                                 "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                                 "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
     def test_change_passwd_stale(self):
         eppn = self.test_user_data['eduPersonPrincipalName']
@@ -760,14 +760,14 @@ class ChangePasswordTests(EduidAPITestCase):
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                response2 = client.post('/change-password', data=json.dumps(data),
+                response2 = client.post('/chpass/change-password', data=json.dumps(data),
                                         content_type=self.content_type_json)
 
                 self.assertEqual(response2.status_code, 200)
 
                 sec_data = json.loads(response2.data)
                 self.assertEqual(sec_data['type'],
-                                 "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                                 "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_change_passwd_no_csrf(self, mock_request_user_sync):
@@ -775,21 +775,21 @@ class ChangePasswordTests(EduidAPITestCase):
         eppn = self.test_user_data['eduPersonPrincipalName']
         with self.session_cookie(self.browser, eppn) as client:
             with client.session_transaction() as sess:
-                with patch('eduid_webapp.reset_password.views.change_password.add_credentials',
+                with patch('eduid_webapp.reset_password.views.change_password.change_password',
                            return_value=True):
                     sess['reauthn-for-chpass'] = int(time.time())
                     data = {
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                    response2 = client.post('/change-password', data=json.dumps(data),
+                    response2 = client.post('/chpass/change-password', data=json.dumps(data),
                                             content_type=self.content_type_json)
 
                     self.assertEqual(response2.status_code, 200)
 
                     sec_data = json.loads(response2.data)
                     self.assertEqual(sec_data['type'],
-                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                                     "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_change_passwd_wrong_csrf(self, mock_request_user_sync):
@@ -797,19 +797,19 @@ class ChangePasswordTests(EduidAPITestCase):
         eppn = self.test_user_data['eduPersonPrincipalName']
         with self.session_cookie(self.browser, eppn) as client:
             with client.session_transaction() as sess:
-                with patch('eduid_webapp.reset_password.views.change_password.add_credentials', return_value=True):
+                with patch('eduid_webapp.reset_password.views.change_password.change_password', return_value=True):
                     sess['reauthn-for-chpass'] = int(time.time())
                     data = {
                             'csrf_token': '0000',
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                    response2 = client.post('/change-password', data=json.dumps(data),
+                    response2 = client.post('/chpass/change-password', data=json.dumps(data),
                                             content_type=self.content_type_json)
 
                     sec_data = json.loads(response2.data)
                     self.assertEqual(sec_data['type'],
-                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                                     "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_change_passwd(self, mock_request_user_sync):
@@ -817,7 +817,7 @@ class ChangePasswordTests(EduidAPITestCase):
         eppn = self.test_user_data['eduPersonPrincipalName']
         with self.session_cookie(self.browser, eppn) as client:
             with client.session_transaction() as sess:
-                with patch('eduid_webapp.reset_password.views.change_password.add_credentials', return_value=True):
+                with patch('eduid_webapp.reset_password.views.change_password.change_password', return_value=True):
                     sess['reauthn-for-chpass'] = int(time.time())
                     with self.app.test_request_context():
                         data = {
@@ -825,14 +825,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                 'new_password': '1234',
                                 'old_password': '5678'
                                 }
-                    response2 = client.post('/change-password', data=json.dumps(data),
+                    response2 = client.post('/chpass/change-password', data=json.dumps(data),
                                             content_type=self.content_type_json)
 
                     self.assertEqual(response2.status_code, 200)
 
                     sec_data = json.loads(response2.data)
                     self.assertEqual(sec_data['type'],
-                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
+                                     "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_SUCCESS")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_get_suggested_and_change(self, mock_request_user_sync):
@@ -845,7 +845,7 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/suggested-password')
+                                response2 = client.get('/chpass/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
                                                  'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
@@ -857,14 +857,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': password,
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/change-password', data=json.dumps(data),
+                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
+                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_SUCCESS")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -900,7 +900,7 @@ class ChangePasswordTests(EduidAPITestCase):
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
+                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_SUCCESS")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -936,7 +936,7 @@ class ChangePasswordTests(EduidAPITestCase):
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -972,7 +972,7 @@ class ChangePasswordTests(EduidAPITestCase):
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)

--- a/src/eduid_webapp/reset_password/tests/test_app.py
+++ b/src/eduid_webapp/reset_password/tests/test_app.py
@@ -81,7 +81,7 @@ class ResetPasswordTests(EduidAPITestCase):
             'email_code_timeout': 7200,
             'phone_code_timeout': 600,
             'password_entropy': 25,
-            'no_authn_urls': [r'^(?!/chpass).*$']
+            'no_authn_urls': [r'/reset.*']
         })
         return ResetPasswordConfig(**config)
 
@@ -100,7 +100,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -113,10 +113,10 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': 'unknown@unplaced.un'
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_FAIL')
             self.assertEqual(response.json['payload']['message'], 'resetpw.user-not-found')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -126,7 +126,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -140,7 +140,7 @@ class ResetPasswordTests(EduidAPITestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEquals(response.json['payload']['extra_security']['phone_numbers'][0],
                               'XXXXXXXXXX09')
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_CONFIG_SUCCESS')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_CONFIG_SUCCESS')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_post_reset_wrong_code(self, mock_sendmail):
@@ -149,7 +149,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -162,7 +162,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             self.assertEquals(response.json['payload']['message'], 'resetpw.unknown-code')
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_CONFIG_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_CONFIG_FAIL')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_post_reset_code_no_extra_sec(self, mock_sendmail):
@@ -171,7 +171,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -189,7 +189,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             self.assertEquals(response.json['payload']['extra_security'], {})
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_CONFIG_SUCCESS')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_CONFIG_SUCCESS')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -202,7 +202,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -227,7 +227,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SUCCESS')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SUCCESS')
 
             # check that the user no longer has verified data
             user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -250,7 +250,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -275,7 +275,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_FAIL')
             self.assertEqual(response.json['payload']['message'], 'resetpw.unknown-code')
 
             # check that the user still has verified data
@@ -296,7 +296,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -330,7 +330,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -353,7 +353,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_EXTRA_SECURITY_SUCCESS')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_EXTRA_SECURITY_SUCCESS')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -368,7 +368,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
             state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
@@ -391,7 +391,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_EXTRA_SECURITY_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_EXTRA_SECURITY_FAIL')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -406,7 +406,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -434,7 +434,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_SUCCESS')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SECURE_SUCCESS')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -449,7 +449,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -477,7 +477,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SECURE_FAIL')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -492,7 +492,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -520,7 +520,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SECURE_FAIL')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -536,7 +536,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -566,7 +566,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SECURE_FAIL')
             self.assertEqual(response.json['payload']['message'], 'resetpw.expired-email-code')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
@@ -583,7 +583,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -613,7 +613,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_FAIL')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SECURE_FAIL')
             self.assertEqual(response.json['payload']['message'], 'resetpw.expired-sms-code')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
@@ -629,7 +629,7 @@ class ResetPasswordTests(EduidAPITestCase):
             data = {
                 'email': self.test_user_email
             }
-            response = c.post('/', data=json.dumps(data),
+            response = c.post('/reset/', data=json.dumps(data),
                               content_type=self.content_type_json)
             self.assertEqual(response.status_code, 200)
 
@@ -657,7 +657,7 @@ class ResetPasswordTests(EduidAPITestCase):
                               content_type=self.content_type_json)
 
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_SUCCESS')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_RESET_NEW_PASSWORD_SECURE_SUCCESS')
 
             # check that the password is marked as generated
             user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -712,11 +712,11 @@ class ChangePasswordTests(EduidAPITestCase):
         self.assertEqual(response.status_code, 302)  # Redirect to token service
         with self.session_cookie(self.browser, eppn) as client:
 
-            response2 = client.get('/chpass/suggested-password')
+            response2 = client.get('/suggested-password')
 
             passwd = json.loads(response2.data)
             self.assertEqual(passwd['type'],
-                             "GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS")
+                             "GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS")
 
     def test_change_passwd_no_data(self):
         response = self.browser.post('/change-password')
@@ -724,11 +724,11 @@ class ChangePasswordTests(EduidAPITestCase):
 
         eppn = self.test_user_data['eduPersonPrincipalName']
         with self.session_cookie(self.browser, eppn) as client:
-            response2 = client.post('/chpass/change-password')
+            response2 = client.post('/change-password')
 
             sec_data = json.loads(response2.data)
             self.assertEqual(sec_data['type'],
-                             "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                             "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
     def test_change_passwd_no_reauthn(self):
         eppn = self.test_user_data['eduPersonPrincipalName']
@@ -740,14 +740,14 @@ class ChangePasswordTests(EduidAPITestCase):
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                response2 = client.post('/chpass/change-password', data=json.dumps(data),
+                response2 = client.post('/change-password', data=json.dumps(data),
                                         content_type=self.content_type_json)
 
                 self.assertEqual(response2.status_code, 200)
 
                 sec_data = json.loads(response2.data)
                 self.assertEqual(sec_data['type'],
-                                 "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                                 "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
     def test_change_passwd_stale(self):
         eppn = self.test_user_data['eduPersonPrincipalName']
@@ -760,14 +760,14 @@ class ChangePasswordTests(EduidAPITestCase):
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                response2 = client.post('/chpass/change-password', data=json.dumps(data),
+                response2 = client.post('/change-password', data=json.dumps(data),
                                         content_type=self.content_type_json)
 
                 self.assertEqual(response2.status_code, 200)
 
                 sec_data = json.loads(response2.data)
                 self.assertEqual(sec_data['type'],
-                                 "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                                 "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_change_passwd_no_csrf(self, mock_request_user_sync):
@@ -782,14 +782,14 @@ class ChangePasswordTests(EduidAPITestCase):
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                    response2 = client.post('/chpass/change-password', data=json.dumps(data),
+                    response2 = client.post('/change-password', data=json.dumps(data),
                                             content_type=self.content_type_json)
 
                     self.assertEqual(response2.status_code, 200)
 
                     sec_data = json.loads(response2.data)
                     self.assertEqual(sec_data['type'],
-                                     "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_change_passwd_wrong_csrf(self, mock_request_user_sync):
@@ -804,12 +804,12 @@ class ChangePasswordTests(EduidAPITestCase):
                             'new_password': '1234',
                             'old_password': '5678'
                             }
-                    response2 = client.post('/chpass/change-password', data=json.dumps(data),
+                    response2 = client.post('/change-password', data=json.dumps(data),
                                             content_type=self.content_type_json)
 
                     sec_data = json.loads(response2.data)
                     self.assertEqual(sec_data['type'],
-                                     "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_change_passwd(self, mock_request_user_sync):
@@ -825,14 +825,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                 'new_password': '1234',
                                 'old_password': '5678'
                                 }
-                    response2 = client.post('/chpass/change-password', data=json.dumps(data),
+                    response2 = client.post('/change-password', data=json.dumps(data),
                                             content_type=self.content_type_json)
 
                     self.assertEqual(response2.status_code, 200)
 
                     sec_data = json.loads(response2.data)
                     self.assertEqual(sec_data['type'],
-                                     "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_SUCCESS")
+                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
 
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     def test_get_suggested_and_change(self, mock_request_user_sync):
@@ -845,10 +845,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/chpass/suggested-password')
+                                response2 = client.get('/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -857,14 +857,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': password,
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
+                                response3 = client.post('/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_SUCCESS")
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -881,10 +881,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/chpass/suggested-password')
+                                response2 = client.get('/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -893,14 +893,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': 'another-password',
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
+                                response3 = client.post('/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_SUCCESS")
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -917,10 +917,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/chpass/suggested-password')
+                                response2 = client.get('/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -929,14 +929,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': password,
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
+                                response3 = client.post('/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -953,10 +953,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=False):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/chpass/suggested-password')
+                                response2 = client.get('/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -965,14 +965,14 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': password,
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
+                                response3 = client.post('/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
 
         sec_data = json.loads(response3.data)
         self.assertEqual(sec_data['type'],
-                         "POST_CHANGE_PASSWORD_CHPASS_CHANGE_PASSWORD_FAIL")
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
 
         # check that the password is marked as generated
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)

--- a/src/eduid_webapp/reset_password/tests/test_app.py
+++ b/src/eduid_webapp/reset_password/tests/test_app.py
@@ -34,6 +34,7 @@
 from __future__ import absolute_import
 
 import json
+import time
 from base64 import b64encode
 
 from flask import url_for
@@ -142,6 +143,28 @@ class ResetPasswordTests(EduidAPITestCase):
             self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_CONFIG_SUCCESS')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    def test_post_reset_wrong_code(self, mock_sendmail):
+        mock_sendmail.return_value = True
+        with self.app.test_client() as c:
+            data = {
+                'email': self.test_user_email
+            }
+            response = c.post('/', data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            url = url_for('reset_password.config_reset_pw',
+                           _external=True)
+            data = {
+                'code': 'wrong-code'
+            }
+            response = c.post(url, data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
+            self.assertEquals(response.json['payload']['message'], 'resetpw.unknown-code')
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_CONFIG_FAIL')
+
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_post_reset_code_no_extra_sec(self, mock_sendmail):
         mock_sendmail.return_value = True
         with self.app.test_client() as c:
@@ -207,7 +230,7 @@ class ResetPasswordTests(EduidAPITestCase):
             self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SUCCESS')
 
             # check that the user no longer has verified data
-            user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
+            user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
             verified_phone_numbers = user.phone_numbers.verified.to_list()
             self.assertEquals(len(verified_phone_numbers), 0)
             verified_nins = user.nins.verified.to_list()
@@ -215,6 +238,52 @@ class ResetPasswordTests(EduidAPITestCase):
 
             # check that the password is marked as generated
             self.assertTrue(user.credentials.to_list()[0].is_generated)
+
+    @patch('eduid_common.authn.vccs.get_vccs_client')
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_post_reset_password_wrong_code(self, mock_request_user_sync, mock_sendmail, mock_get_vccs_client):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        mock_sendmail.return_value = True
+        mock_get_vccs_client.return_value = TestVCCSClient()
+        with self.app.test_client() as c:
+            data = {
+                'email': self.test_user_email
+            }
+            response = c.post('/', data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+
+            # check that the user has verified data
+            user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
+            verified_phone_numbers = user.phone_numbers.verified.to_list()
+            self.assertEquals(len(verified_phone_numbers), 1)
+            verified_nins = user.nins.verified.to_list()
+            self.assertEquals(len(verified_nins), 2)
+
+            with c.session_transaction() as session:
+                new_password = generate_suggested_password()
+                session.reset_password.generated_password_hash = hash_password(new_password)
+                url = url_for('reset_password.set_new_pw', _external=True)
+                data = {
+                    'code': 'wrong-code',
+                    'password': new_password
+                }
+
+            response = c.post(url, data=json.dumps(data),
+                              content_type=self.content_type_json)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_FAIL')
+            self.assertEqual(response.json['payload']['message'], 'resetpw.unknown-code')
+
+            # check that the user still has verified data
+            user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
+            verified_phone_numbers = user.phone_numbers.verified.to_list()
+            self.assertEquals(len(verified_phone_numbers), 1)
+            verified_nins = user.nins.verified.to_list()
+            self.assertEquals(len(verified_nins), 2)
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -290,6 +359,44 @@ class ResetPasswordTests(EduidAPITestCase):
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     @patch('eduid_common.api.am.AmRelay.request_user_sync')
     @patch('eduid_common.api.msg.MsgRelay.sendsms')
+    def test_post_choose_extra_sec_wrong_code(self, mock_sendsms, mock_request_user_sync, mock_sendmail, mock_get_vccs_client):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        mock_sendmail.return_value = True
+        mock_get_vccs_client.return_value = TestVCCSClient()
+        mock_sendsms.return_value = True
+        with self.app.test_client() as c:
+            data = {
+                'email': self.test_user_email
+            }
+            response = c.post('/', data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+
+            url = url_for('reset_password.config_reset_pw', _external=True)
+            data = {
+                'code': 'wrong-code'
+            }
+            response = c.post(url, data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
+
+            url = url_for('reset_password.choose_extra_security', _external=True)
+            data = {
+                'code': state.email_code.code,
+                'phone_index': '0'
+            }
+
+            response = c.post(url, data=json.dumps(data),
+                              content_type=self.content_type_json)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_EXTRA_SECURITY_FAIL')
+
+    @patch('eduid_common.authn.vccs.get_vccs_client')
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    @patch('eduid_common.api.msg.MsgRelay.sendsms')
     def test_post_reset_password_secure(self, mock_sendsms, mock_request_user_sync, mock_sendmail, mock_get_vccs_client):
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_sendmail.return_value = True
@@ -329,15 +436,91 @@ class ResetPasswordTests(EduidAPITestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_SUCCESS')
 
-            # check that the user still has verified data
-            user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
-            verified_phone_numbers = user.phone_numbers.verified.to_list()
-            self.assertEquals(len(verified_phone_numbers), 1)
-            verified_nins = user.nins.verified.to_list()
-            self.assertEquals(len(verified_nins), 2)
+    @patch('eduid_common.authn.vccs.get_vccs_client')
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    @patch('eduid_common.api.msg.MsgRelay.sendsms')
+    def test_post_reset_password_secure_wrong_email_code(self, mock_sendsms, mock_request_user_sync, mock_sendmail, mock_get_vccs_client):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        mock_sendmail.return_value = True
+        mock_get_vccs_client.return_value = TestVCCSClient()
+        mock_sendsms.return_value = True
+        with self.app.test_client() as c:
+            data = {
+                'email': self.test_user_email
+            }
+            response = c.post('/', data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
 
-            # check that the password is marked as generated
-            self.assertTrue(user.credentials.to_list()[0].is_generated)
+            user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            alternatives = get_extra_security_alternatives(user)
+            state.extra_security = alternatives
+            state.email_code.is_verified = True
+            self.app.password_reset_state_db.save(state)
+            phone_number = state.extra_security['phone_numbers'][0]
+            send_verify_phone_code(state, phone_number)
+
+            with c.session_transaction() as session:
+                new_password = generate_suggested_password()
+                session.reset_password.generated_password_hash = hash_password(new_password)
+                url = url_for('reset_password.set_new_pw_extra_security', _external=True)
+                state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+                data = {
+                    'code': 'wrong-code',
+                    'phone_code': state.phone_code.code,
+                    'password': new_password
+                }
+
+            response = c.post(url, data=json.dumps(data),
+                              content_type=self.content_type_json)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_FAIL')
+
+    @patch('eduid_common.authn.vccs.get_vccs_client')
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    @patch('eduid_common.api.msg.MsgRelay.sendsms')
+    def test_post_reset_password_secure_wrong_phone_code(self, mock_sendsms, mock_request_user_sync, mock_sendmail, mock_get_vccs_client):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        mock_sendmail.return_value = True
+        mock_get_vccs_client.return_value = TestVCCSClient()
+        mock_sendsms.return_value = True
+        with self.app.test_client() as c:
+            data = {
+                'email': self.test_user_email
+            }
+            response = c.post('/', data=json.dumps(data),
+                              content_type=self.content_type_json)
+            self.assertEqual(response.status_code, 200)
+
+            user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            alternatives = get_extra_security_alternatives(user)
+            state.extra_security = alternatives
+            state.email_code.is_verified = True
+            self.app.password_reset_state_db.save(state)
+            phone_number = state.extra_security['phone_numbers'][0]
+            send_verify_phone_code(state, phone_number)
+
+            with c.session_transaction() as session:
+                new_password = generate_suggested_password()
+                session.reset_password.generated_password_hash = hash_password(new_password)
+                url = url_for('reset_password.set_new_pw_extra_security', _external=True)
+                state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+                data = {
+                    'code': state.phone_code.code,
+                    'phone_code': 'wrong-code',
+                    'password': new_password
+                }
+
+            response = c.post(url, data=json.dumps(data),
+                              content_type=self.content_type_json)
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json['type'], 'POST_RESET_PASSWORD_NEW_PASSWORD_SECURE_FAIL')
 
     @patch('eduid_common.authn.vccs.get_vccs_client')
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
@@ -479,3 +662,318 @@ class ResetPasswordTests(EduidAPITestCase):
             # check that the password is marked as generated
             user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
             self.assertFalse(user.credentials.to_list()[0].is_generated)
+
+
+class ChangePasswordTests(EduidAPITestCase):
+    """Base TestCase for those tests that need a full environment setup"""
+
+    def setUp(self):
+        self.test_user_eppn = 'hubba-bubba'
+        self.test_user_email = 'johnsmith@example.com'
+        self.test_user_nin = '197801011235'
+        super(ChangePasswordTests, self).setUp(copy_user_to_private=True)
+
+    def load_app(self, config):
+        """
+        Called from the parent class, so we can provide the appropriate flask
+        app for this test case.
+        """
+        return init_reset_password_app('testing', config)
+
+    def update_config(self, config):
+        config.update({
+            'available_languages': {'en': 'English', 'sv': 'Svenska'},
+            'msg_broker_url': 'amqp://dummy',
+            'am_broker_url': 'amqp://dummy',
+            'celery_config': {
+                'result_backend': 'amqp',
+                'task_serializer': 'json'
+            },
+            'vccs_url': 'http://vccs',
+            'email_code_timeout': 7200,
+            'phone_code_timeout': 600,
+            'password_length': 12,
+            'password_entropy': 25,
+            'chpass_timeout': 600,
+        })
+        return ResetPasswordConfig(**config)
+
+    def tearDown(self):
+        super(ChangePasswordTests, self).tearDown()
+        with self.app.app_context():
+            self.app.central_userdb._drop_whole_collection()
+
+    def test_app_starts(self):
+        self.assertEquals(self.app.config.app_name, "reset_password") 
+
+    def test_get_suggested(self):
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        response = self.browser.get('/suggested-password')
+        self.assertEqual(response.status_code, 302)  # Redirect to token service
+        with self.session_cookie(self.browser, eppn) as client:
+
+            response2 = client.get('/suggested-password')
+
+            passwd = json.loads(response2.data)
+            self.assertEqual(passwd['type'],
+                             "GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS")
+
+    def test_change_passwd_no_data(self):
+        response = self.browser.post('/change-password')
+        self.assertEqual(response.status_code, 302)  # Redirect to token service
+
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.session_cookie(self.browser, eppn) as client:
+            response2 = client.post('/change-password')
+
+            sec_data = json.loads(response2.data)
+            self.assertEqual(sec_data['type'],
+                             "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+    def test_change_passwd_no_reauthn(self):
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.session_cookie(self.browser, eppn) as client:
+            with client.session_transaction() as sess:
+                with self.app.test_request_context():
+                    data = {
+                            'csrf_token': sess.get_csrf_token(),
+                            'new_password': '1234',
+                            'old_password': '5678'
+                            }
+                response2 = client.post('/change-password', data=json.dumps(data),
+                                        content_type=self.content_type_json)
+
+                self.assertEqual(response2.status_code, 200)
+
+                sec_data = json.loads(response2.data)
+                self.assertEqual(sec_data['type'],
+                                 "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+    def test_change_passwd_stale(self):
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.session_cookie(self.browser, eppn) as client:
+            with client.session_transaction() as sess:
+                sess['reauthn-for-chpass'] = True
+                with self.app.test_request_context():
+                    data = {
+                            'csrf_token': sess.get_csrf_token(),
+                            'new_password': '1234',
+                            'old_password': '5678'
+                            }
+                response2 = client.post('/change-password', data=json.dumps(data),
+                                        content_type=self.content_type_json)
+
+                self.assertEqual(response2.status_code, 200)
+
+                sec_data = json.loads(response2.data)
+                self.assertEqual(sec_data['type'],
+                                 "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_change_passwd_no_csrf(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.session_cookie(self.browser, eppn) as client:
+            with client.session_transaction() as sess:
+                with patch('eduid_webapp.reset_password.views.change_password.add_credentials',
+                           return_value=True):
+                    sess['reauthn-for-chpass'] = int(time.time())
+                    data = {
+                            'new_password': '1234',
+                            'old_password': '5678'
+                            }
+                    response2 = client.post('/change-password', data=json.dumps(data),
+                                            content_type=self.content_type_json)
+
+                    self.assertEqual(response2.status_code, 200)
+
+                    sec_data = json.loads(response2.data)
+                    self.assertEqual(sec_data['type'],
+                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_change_passwd_wrong_csrf(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.session_cookie(self.browser, eppn) as client:
+            with client.session_transaction() as sess:
+                with patch('eduid_webapp.reset_password.views.change_password.add_credentials', return_value=True):
+                    sess['reauthn-for-chpass'] = int(time.time())
+                    data = {
+                            'csrf_token': '0000',
+                            'new_password': '1234',
+                            'old_password': '5678'
+                            }
+                    response2 = client.post('/change-password', data=json.dumps(data),
+                                            content_type=self.content_type_json)
+
+                    sec_data = json.loads(response2.data)
+                    self.assertEqual(sec_data['type'],
+                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_change_passwd(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.session_cookie(self.browser, eppn) as client:
+            with client.session_transaction() as sess:
+                with patch('eduid_webapp.reset_password.views.change_password.add_credentials', return_value=True):
+                    sess['reauthn-for-chpass'] = int(time.time())
+                    with self.app.test_request_context():
+                        data = {
+                                'csrf_token': sess.get_csrf_token(),
+                                'new_password': '1234',
+                                'old_password': '5678'
+                                }
+                    response2 = client.post('/change-password', data=json.dumps(data),
+                                            content_type=self.content_type_json)
+
+                    self.assertEqual(response2.status_code, 200)
+
+                    sec_data = json.loads(response2.data)
+                    self.assertEqual(sec_data['type'],
+                                     "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_get_suggested_and_change(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.app.test_request_context():
+            with self.session_cookie(self.browser, eppn) as client:
+                with client.session_transaction() as sess:
+                    with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.add_credentials', return_value=True):
+                        with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
+                            with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
+                                sess['reauthn-for-chpass'] = int(time.time())
+                                response2 = client.get('/suggested-password')
+                                passwd = json.loads(response2.data)
+                                self.assertEqual(passwd['type'],
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                password = passwd['payload']['suggested_password']
+                                sess.reset_password.generated_password_hash = hash_password(password)
+                                sess.persist()
+                                data = {
+                                        'csrf_token': sess.get_csrf_token(),
+                                        'new_password': password,
+                                        'old_password': '5678'
+                                        }
+                                response3 = client.post('/change-password', data=json.dumps(data),
+                                                        content_type=self.content_type_json)
+
+        self.assertEqual(response3.status_code, 200)
+
+        sec_data = json.loads(response3.data)
+        self.assertEqual(sec_data['type'],
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
+
+        # check that the password is marked as generated
+        user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
+        self.assertTrue(user.credentials.to_list()[-1].is_generated)
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_get_suggested_and_change_custom(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.app.test_request_context():
+            with self.session_cookie(self.browser, eppn) as client:
+                with client.session_transaction() as sess:
+                    with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.add_credentials', return_value=True):
+                        with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
+                            with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
+                                sess['reauthn-for-chpass'] = int(time.time())
+                                response2 = client.get('/suggested-password')
+                                passwd = json.loads(response2.data)
+                                self.assertEqual(passwd['type'],
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                password = passwd['payload']['suggested_password']
+                                sess.reset_password.generated_password_hash = hash_password(password)
+                                sess.persist()
+                                data = {
+                                        'csrf_token': sess.get_csrf_token(),
+                                        'new_password': 'another-password',
+                                        'old_password': '5678'
+                                        }
+                                response3 = client.post('/change-password', data=json.dumps(data),
+                                                        content_type=self.content_type_json)
+
+        self.assertEqual(response3.status_code, 200)
+
+        sec_data = json.loads(response3.data)
+        self.assertEqual(sec_data['type'],
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_SUCCESS")
+
+        # check that the password is marked as generated
+        user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
+        self.assertFalse(user.credentials.to_list()[-1].is_generated)
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_get_suggested_and_change_wrong_csrf(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.app.test_request_context():
+            with self.session_cookie(self.browser, eppn) as client:
+                with client.session_transaction() as sess:
+                    with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.add_credentials', return_value=True):
+                        with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
+                            with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
+                                sess['reauthn-for-chpass'] = int(time.time())
+                                response2 = client.get('/suggested-password')
+                                passwd = json.loads(response2.data)
+                                self.assertEqual(passwd['type'],
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                password = passwd['payload']['suggested_password']
+                                sess.reset_password.generated_password_hash = hash_password(password)
+                                sess.persist()
+                                data = {
+                                        'csrf_token': 'wrong-csrf-token',
+                                        'new_password': password,
+                                        'old_password': '5678'
+                                        }
+                                response3 = client.post('/change-password', data=json.dumps(data),
+                                                        content_type=self.content_type_json)
+
+        self.assertEqual(response3.status_code, 200)
+
+        sec_data = json.loads(response3.data)
+        self.assertEqual(sec_data['type'],
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+        # check that the password is marked as generated
+        user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
+        self.assertFalse(user.credentials.to_list()[-1].is_generated)
+
+    @patch('eduid_common.api.am.AmRelay.request_user_sync')
+    def test_get_suggested_and_change_wrong_old_pw(self, mock_request_user_sync):
+        mock_request_user_sync.side_effect = self.request_user_sync
+        eppn = self.test_user_data['eduPersonPrincipalName']
+        with self.app.test_request_context():
+            with self.session_cookie(self.browser, eppn) as client:
+                with client.session_transaction() as sess:
+                    with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.add_credentials', return_value=True):
+                        with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
+                            with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=False):
+                                sess['reauthn-for-chpass'] = int(time.time())
+                                response2 = client.get('/suggested-password')
+                                passwd = json.loads(response2.data)
+                                self.assertEqual(passwd['type'],
+                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                password = passwd['payload']['suggested_password']
+                                sess.reset_password.generated_password_hash = hash_password(password)
+                                sess.persist()
+                                data = {
+                                        'csrf_token': sess.get_csrf_token(),
+                                        'new_password': password,
+                                        'old_password': '5678'
+                                        }
+                                response3 = client.post('/change-password', data=json.dumps(data),
+                                                        content_type=self.content_type_json)
+
+        self.assertEqual(response3.status_code, 200)
+
+        sec_data = json.loads(response3.data)
+        self.assertEqual(sec_data['type'],
+                         "POST_CHANGE_PASSWORD_CHANGE_PASSWORD_FAIL")
+
+        # check that the password is marked as generated
+        user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
+        self.assertFalse(user.credentials.to_list()[-1].is_generated)

--- a/src/eduid_webapp/reset_password/tests/test_app.py
+++ b/src/eduid_webapp/reset_password/tests/test_app.py
@@ -81,7 +81,7 @@ class ResetPasswordTests(EduidAPITestCase):
             'email_code_timeout': 7200,
             'phone_code_timeout': 600,
             'password_entropy': 25,
-            'no_authn_urls': ["^/"]
+            'no_authn_urls': [r'^(?!/chpass).*$']
         })
         return ResetPasswordConfig(**config)
 
@@ -716,7 +716,7 @@ class ChangePasswordTests(EduidAPITestCase):
 
             passwd = json.loads(response2.data)
             self.assertEqual(passwd['type'],
-                             "GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS")
+                             "GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS")
 
     def test_change_passwd_no_data(self):
         response = self.browser.post('/change-password')
@@ -848,7 +848,7 @@ class ChangePasswordTests(EduidAPITestCase):
                                 response2 = client.get('/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -881,10 +881,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/suggested-password')
+                                response2 = client.get('/chpass/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -893,7 +893,7 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': 'another-password',
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/change-password', data=json.dumps(data),
+                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
@@ -917,10 +917,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=True):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/suggested-password')
+                                response2 = client.get('/chpass/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -929,7 +929,7 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': password,
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/change-password', data=json.dumps(data),
+                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)
@@ -953,10 +953,10 @@ class ChangePasswordTests(EduidAPITestCase):
                         with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.revoke_credentials', return_value=True):
                             with patch('eduid_common.authn.vccs.vccs_client.VCCSClient.authenticate', return_value=False):
                                 sess['reauthn-for-chpass'] = int(time.time())
-                                response2 = client.get('/suggested-password')
+                                response2 = client.get('/chpass/suggested-password')
                                 passwd = json.loads(response2.data)
                                 self.assertEqual(passwd['type'],
-                                                 'GET_CHANGE_PASSWORD_SUGGESTED_PASSWORD_SUCCESS')
+                                                 'GET_CHANGE_PASSWORD_CHPASS_SUGGESTED_PASSWORD_SUCCESS')
                                 password = passwd['payload']['suggested_password']
                                 sess.reset_password.generated_password_hash = hash_password(password)
                                 sess.persist()
@@ -965,7 +965,7 @@ class ChangePasswordTests(EduidAPITestCase):
                                         'new_password': password,
                                         'old_password': '5678'
                                         }
-                                response3 = client.post('/change-password', data=json.dumps(data),
+                                response3 = client.post('/chpass/change-password', data=json.dumps(data),
                                                         content_type=self.content_type_json)
 
         self.assertEqual(response3.status_code, 200)

--- a/src/eduid_webapp/reset_password/views/change_password.py
+++ b/src/eduid_webapp/reset_password/views/change_password.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 SUNET
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the NORDUnet nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import absolute_import
+
+from base64 import b64encode
+from datetime import datetime
+
+from flask import Blueprint
+
+from eduid_userdb.exceptions import UserOutOfSync
+from eduid_userdb.reset_password import ResetPasswordUser
+from eduid_common.api.decorators import require_user, MarshalWith, UnmarshalWith
+from eduid_common.api.utils import save_and_sync_user
+from eduid_common.authn.vccs import add_credentials
+from eduid_common.session import session
+from eduid_common.api.schemas.password import CredentialList
+from eduid_webapp.reset_password.helpers import compile_credential_list
+from eduid_webapp.reset_password.helpers import generate_suggested_password
+from eduid_webapp.reset_password.helpers import hash_password, check_password
+from eduid_webapp.reset_password.helpers import ResetPwMsg
+from eduid_webapp.reset_password.schemas import ChangePasswordSchema
+from eduid_webapp.reset_password.schemas import ChpassResponseSchema
+from eduid_webapp.reset_password.schemas import SuggestedPassword, SuggestedPasswordResponseSchema
+from eduid_webapp.reset_password.helpers import error_message
+from eduid_webapp.reset_password.app import current_reset_password_app as current_app
+
+change_password_views = Blueprint('change_password', __name__, url_prefix='', template_folder='templates')
+
+
+@change_password_views.route('/suggested-password', methods=['GET'])
+@MarshalWith(SuggestedPasswordResponseSchema)
+@require_user
+def get_suggested(user):
+    """
+    View to get a suggested  password for the logged user.
+    """
+    current_app.logger.debug(f'Sending new generated password for {user}')
+    password = generate_suggested_password()
+
+    session.reset_password.generated_password_hash = hash_password(password)
+
+    suggested = {
+            'suggested_password': password
+            }
+
+    return SuggestedPassword().dump(suggested).data
+
+
+@change_password_views.route('/change-password', methods=['POST'])
+@MarshalWith(ChpassResponseSchema)
+@UnmarshalWith(ChangePasswordSchema)
+@require_user
+def change_password(user, old_password, new_password):
+    """
+    View to change the password
+    """
+    resetpw_user = ResetPasswordUser.from_user(user, current_app.private_userdb)
+    authn_ts = session.get('reauthn', None)
+    if authn_ts is None:
+        return error_message(ResetPwMsg.no_reauthn)
+
+    now = datetime.utcnow()
+    delta = now - datetime.fromtimestamp(authn_ts)
+    timeout = current_app.config.chpass_timeout
+    if int(delta.total_seconds()) > timeout:
+        return error_message(ResetPwMsg.stale_reauthn)
+
+    hashed = session.reset_password.generated_password_hash
+    if check_password(new_password, hashed):
+        is_generated = True
+        current_app.stats.count(name='change_password_generated_password_used')
+    else:
+        is_generated = False
+        current_app.stats.count(name='change_password_custom_password_used')
+
+    vccs_url = current_app.config.vccs_url
+    added = add_credentials(vccs_url, old_password, new_password, resetpw_user,
+                                   is_generated=is_generated, source='security')
+
+    if not added:
+        current_app.logger.debug(f'Problem verifying the old credentials for {user}')
+        return error_message(ResetPwMsg.unrecognized_pw)
+
+    resetpw_user.terminated = False
+    try:
+        save_and_sync_user(resetpw_user)
+    except UserOutOfSync:
+        return error_message(ResetPwMsg.out_of_sync)
+
+    del session['reauthn-for-chpass']
+
+    current_app.stats.count(name='security_password_changed', value=1)
+    current_app.logger.info(f'Changed password for user {resetpw_user.eppn}')
+
+    next_url = current_app.config.dashboard_url
+    credentials = {
+        'next_url': next_url,
+        'credentials': compile_credential_list(resetpw_user),
+        'message': 'chpass.password-changed'
+        }
+
+    return CredentialList().dump(credentials).data

--- a/src/eduid_webapp/reset_password/views/change_password.py
+++ b/src/eduid_webapp/reset_password/views/change_password.py
@@ -30,10 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-
-from __future__ import absolute_import
-
-from base64 import b64encode
 from datetime import datetime
 
 from flask import Blueprint
@@ -55,7 +51,7 @@ from eduid_webapp.reset_password.schemas import SuggestedPassword, SuggestedPass
 from eduid_webapp.reset_password.helpers import error_message
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
-change_password_views = Blueprint('change_password', __name__, url_prefix='', template_folder='templates')
+change_password_views = Blueprint('change_password', __name__, url_prefix='')
 
 
 @change_password_views.route('/suggested-password', methods=['GET'])

--- a/src/eduid_webapp/reset_password/views/change_password.py
+++ b/src/eduid_webapp/reset_password/views/change_password.py
@@ -51,7 +51,7 @@ from eduid_webapp.reset_password.schemas import SuggestedPassword, SuggestedPass
 from eduid_webapp.reset_password.helpers import error_message
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
-change_password_views = Blueprint('change_password', __name__, url_prefix='/chpass')
+change_password_views = Blueprint('change_password', __name__, url_prefix='')
 
 
 @change_password_views.route('/suggested-password', methods=['GET'])

--- a/src/eduid_webapp/reset_password/views/change_password.py
+++ b/src/eduid_webapp/reset_password/views/change_password.py
@@ -40,7 +40,7 @@ from eduid_common.api.decorators import require_user, MarshalWith, UnmarshalWith
 from eduid_common.api.utils import save_and_sync_user
 from eduid_common.authn.vccs import add_credentials
 from eduid_common.session import session
-from eduid_common.api.schemas.password import CredentialList
+from eduid_webapp.security.schemas import CredentialList
 from eduid_webapp.reset_password.helpers import compile_credential_list
 from eduid_webapp.reset_password.helpers import generate_suggested_password
 from eduid_webapp.reset_password.helpers import hash_password, check_password
@@ -51,7 +51,7 @@ from eduid_webapp.reset_password.schemas import SuggestedPassword, SuggestedPass
 from eduid_webapp.reset_password.helpers import error_message
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
-change_password_views = Blueprint('change_password', __name__, url_prefix='')
+change_password_views = Blueprint('change_password', __name__, url_prefix='/chpass')
 
 
 @change_password_views.route('/suggested-password', methods=['GET'])

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -103,7 +103,7 @@ from eduid_webapp.reset_password.helpers import send_verify_phone_code
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
 
-reset_password_views = Blueprint('reset_password', __name__, url_prefix='', template_folder='templates')
+reset_password_views = Blueprint('reset_password', __name__, url_prefix='/reset', template_folder='templates')
 
 
 @reset_password_views.route('/', methods=['POST'])

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -103,7 +103,7 @@ from eduid_webapp.reset_password.helpers import send_verify_phone_code
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
 
-reset_password_views = Blueprint('reset_password', __name__, url_prefix='/reset')
+reset_password_views = Blueprint('reset_password', __name__, url_prefix='', template_folder='templates')
 
 
 @reset_password_views.route('/', methods=['POST'])

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -103,7 +103,7 @@ from eduid_webapp.reset_password.helpers import send_verify_phone_code
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
 
-reset_password_views = Blueprint('reset_password', __name__, url_prefix='', template_folder='templates')
+reset_password_views = Blueprint('reset_password', __name__, url_prefix='')
 
 
 @reset_password_views.route('/', methods=['POST'])

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -103,7 +103,7 @@ from eduid_webapp.reset_password.helpers import send_verify_phone_code
 from eduid_webapp.reset_password.app import current_reset_password_app as current_app
 
 
-reset_password_views = Blueprint('reset_password', __name__, url_prefix='')
+reset_password_views = Blueprint('reset_password', __name__, url_prefix='/reset')
 
 
 @reset_password_views.route('/', methods=['POST'])


### PR DESCRIPTION
Here we finish the reset password app, with (authenticated) views to change the password, and unauthenticated views to reset the password.

Then there will be a PR for eduid-developer, with configuration for the reset password app, and a tiny PR for eduid-front - so it uses the reset password app rather than the security app (for the views mentioned above).

The switch to use the new app (for the change pasword views) would be done in etcd (after merging the above mentioned eduid-developer PR), changing the "reset_passwd_url" setting in the "jsapps" section. We may have to adjust things in staging related to CORS.

Finally, to switch to the new app for the reset password views, we still have to develop the reset password UI in the (login) front app.