### PR TITLE
Eperez magic code

### DIFF
--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -136,8 +136,8 @@ def get_pwreset_state(email_code: str) -> ResetPasswordState:
     raises BadCode in case of problems
     """
     # Backdoor for the staging and dev environments where a magic code
-    # bypasses verification of the emailed code.
-    # here we retrieve the real code from the session.
+    # bypasses verification of the emailed code, to be used in automated integration tests.
+    # Here we retrieve the real code from the session.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         if email_code == current_app.config.magic_code:
             email_code = session['resetpw_email_verification_code']
@@ -189,8 +189,8 @@ def send_password_reset_mail(email_address: str):
     current_app.password_reset_state_db.save(state)
 
     # Backdoor for the staging and dev environments where a magic code
-    # bypasses verification of the emailed code.
-    # here we store the real code in the session,
+    # bypasses verification of the emailed code, to be used in automated integration tests.
+    # Here we store the real code in the session,
     # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         session['resetpw_email_verification_code'] = state.email_code.code
@@ -370,8 +370,8 @@ def send_verify_phone_code(state: ResetPasswordEmailState, phone_number: str):
     current_app.password_reset_state_db.save(state)
 
     # Backdoor for the staging and dev environments where a magic code
-    # bypasses verification of the sms'ed code.
-    # here we store the real code in the session,
+    # bypasses verification of the sms'd code, to be used in automated integration tests.
+    # Here we store the real code in the session,
     # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         session['resetpw_sms_verification_code'] = state.phone_code.code

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -369,7 +369,7 @@ def send_verify_phone_code(state: ResetPasswordEmailState, phone_number: str):
 
     template = 'reset_password_sms.txt.jinja2'
     context = {
-        'verification_code': state.phone_code.code
+        'verification_code': phone_code
     }
     send_sms(state.phone_number, template, context, state.reference)
     current_app.logger.info(f'Sent password reset sms to user with eppn: {state.eppn}')

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -358,10 +358,15 @@ def verify_email_address(state: ResetPasswordEmailState) -> bool:
 
 
 def send_verify_phone_code(state: ResetPasswordEmailState, phone_number: str):
+    phone_code = get_short_hash()
     state = ResetPasswordEmailAndPhoneState.from_email_state(state,
                                                              phone_number=phone_number,
-                                                             phone_code=get_short_hash())
+                                                             phone_code=phone_code)
     current_app.password_reset_state_db.save(state)
+
+    if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
+        session['resetpw_sms_verification_code'] = phone_code
+
     template = 'reset_password_sms.txt.jinja2'
     context = {
         'verification_code': state.phone_code.code

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -135,6 +135,9 @@ def get_pwreset_state(email_code: str) -> ResetPasswordState:
 
     raises BadCode in case of problems
     """
+    # Backdoor for the staging and dev environments where a magic code
+    # bypasses verification of the emailed code.
+    # here we retrieve the real code from the session.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         if email_code == current_app.config.magic_code:
             email_code = session['resetpw_email_verification_code']
@@ -185,6 +188,10 @@ def send_password_reset_mail(email_address: str):
                                     email_code=get_unique_hash())
     current_app.password_reset_state_db.save(state)
 
+    # Backdoor for the staging and dev environments where a magic code
+    # bypasses verification of the emailed code.
+    # here we store the real code in the session,
+    # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         session['resetpw_email_verification_code'] = state.email_code.code
 
@@ -362,6 +369,10 @@ def send_verify_phone_code(state: ResetPasswordEmailState, phone_number: str):
                                                              phone_code=get_short_hash())
     current_app.password_reset_state_db.save(state)
 
+    # Backdoor for the staging and dev environments where a magic code
+    # bypasses verification of the sms'ed code.
+    # here we store the real code in the session,
+    # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         session['resetpw_sms_verification_code'] = state.phone_code.code
 

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -135,7 +135,7 @@ def get_pwreset_state(email_code: str) -> ResetPasswordState:
 
     raises BadCode in case of problems
     """
-    if current_app.config.environment != 'pro' and current_app.config.magic_code:
+    if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         if email_code == current_app.config.magic_code:
             email_code = session['resetpw_email_verification_code']
 
@@ -186,7 +186,7 @@ def send_password_reset_mail(email_address: str):
                                     email_code=email_code)
     current_app.password_reset_state_db.save(state)
 
-    if current_app.config.environment != 'pro' and current_app.config.magic_code:
+    if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         session['resetpw_email_verification_code'] = email_code
 
     text_template = 'reset_password_email.txt.jinja2'

--- a/src/eduid_webapp/reset_password/settings/common.py
+++ b/src/eduid_webapp/reset_password/settings/common.py
@@ -66,3 +66,5 @@ class ResetPasswordConfig(FlaskConfig):
     # URL to get the js app that can drive the process to reset the password
     password_reset_link: str = 'https://login.eduid.se/reset-password/'
     password_service_url: str = '/services/reset-password/'
+    # magic code for integration tests
+    magic_code: str = ''

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -341,7 +341,7 @@ def set_new_pw_extra_security_phone(phone_code: str, code: str, password: str) -
                                                        raise_on_missing=False)
 
     # Backdoor for the staging and dev environments where a magic code
-    # bypasses verification of the sms'ed code.
+    # bypasses verification of the sms'ed code, to be used in automated integration tests.
     # here we store the real code in the session,
     # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -340,6 +340,10 @@ def set_new_pw_extra_security_phone(phone_code: str, code: str, password: str) -
     user = current_app.central_userdb.get_user_by_eppn(state.eppn,
                                                        raise_on_missing=False)
 
+    # Backdoor for the staging and dev environments where a magic code
+    # bypasses verification of the sms'ed code.
+    # here we store the real code in the session,
+    # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
         if phone_code == current_app.config.magic_code:
             phone_code = session['resetpw_sms_verification_code']

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -340,6 +340,10 @@ def set_new_pw_extra_security_phone(phone_code: str, code: str, password: str) -
     user = current_app.central_userdb.get_user_by_eppn(state.eppn,
                                                        raise_on_missing=False)
 
+    if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
+        if phone_code == current_app.config.magic_code:
+            phone_code = session['resetpw_sms_verification_code']
+
     if phone_code == state.phone_code.code:
         if not verify_phone_number(state):
             current_app.logger.info(f'Could not verify phone code for {user}')

--- a/src/eduid_webapp/security/helpers.py
+++ b/src/eduid_webapp/security/helpers.py
@@ -201,9 +201,14 @@ def verify_email_address(state):
 
 @deprecated("Remove once the password reset views are served from their own webapp")
 def send_verify_phone_code(state, phone_number):
+    phone_code = get_short_hash()
     state = PasswordResetEmailAndPhoneState.from_email_state(state, phone_number=phone_number,
-                                                             phone_code=get_short_hash())
+                                                             phone_code=phone_code)
     current_app.password_reset_state_db.save(state)
+
+    if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
+        session['resetpw_sms_verification_code'] = phone_code
+
     template = 'reset_password_sms.txt.jinja2'
     context = {
         'verification_code': state.phone_code.code

--- a/src/eduid_webapp/security/helpers.py
+++ b/src/eduid_webapp/security/helpers.py
@@ -151,12 +151,15 @@ def send_password_reset_mail(email_address):
         current_app.logger.info("Found no user with the following address: {}.".format(email_address))
         return None
 
-    email_code = get_unique_hash()
-    state = PasswordResetEmailState(eppn=user.eppn, email_address=email_address, email_code=email_code)
+    state = PasswordResetEmailState(eppn=user.eppn, email_address=email_address, email_code=get_unique_hash())
     current_app.password_reset_state_db.save(state)
 
+    # Backdoor for the staging and dev environments where a magic code
+    # bypasses verification of the emailed code, to be used in automated integration tests.
+    # Here we store the real code in the session,
+    # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
-        session['resetpw_email_verification_code'] = email_code
+        session['resetpw_email_verification_code'] = state.email_code.code
 
     text_template = 'reset_password_email.txt.jinja2'
     html_template = 'reset_password_email.html.jinja2'
@@ -201,13 +204,16 @@ def verify_email_address(state):
 
 @deprecated("Remove once the password reset views are served from their own webapp")
 def send_verify_phone_code(state, phone_number):
-    phone_code = get_short_hash()
     state = PasswordResetEmailAndPhoneState.from_email_state(state, phone_number=phone_number,
-                                                             phone_code=phone_code)
+                                                             phone_code=get_short_hash())
     current_app.password_reset_state_db.save(state)
 
+    # Backdoor for the staging and dev environments where a magic code
+    # bypasses verification of the sms'ed code, to be used in automated integration tests.
+    # here we store the real code in the session,
+    # to recover it in case the user sends the magic code.
     if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
-        session['resetpw_sms_verification_code'] = phone_code
+        session['resetpw_sms_verification_code'] = state.phone_code.code
 
     template = 'reset_password_sms.txt.jinja2'
     context = {

--- a/src/eduid_webapp/security/helpers.py
+++ b/src/eduid_webapp/security/helpers.py
@@ -150,8 +150,14 @@ def send_password_reset_mail(email_address):
     if not user:
         current_app.logger.info("Found no user with the following address: {}.".format(email_address))
         return None
-    state = PasswordResetEmailState(eppn=user.eppn, email_address=email_address, email_code=get_unique_hash())
+
+    email_code = get_unique_hash()
+    state = PasswordResetEmailState(eppn=user.eppn, email_address=email_address, email_code=email_code)
     current_app.password_reset_state_db.save(state)
+
+    if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
+        session['resetpw_email_verification_code'] = email_code
+
     text_template = 'reset_password_email.txt.jinja2'
     html_template = 'reset_password_email.html.jinja2'
     to_addresses = [address.email for address in user.mail_addresses.verified.to_list()]

--- a/src/eduid_webapp/security/settings/common.py
+++ b/src/eduid_webapp/security/settings/common.py
@@ -62,3 +62,5 @@ class SecurityConfig(FlaskConfig):
     # password reset settings
     email_code_timeout: int = 7200  # seconds
     phone_code_timeout: int = 600  # seconds
+    # magic code for integration tests
+    magic_code: str = ''

--- a/src/eduid_webapp/security/tests/test_reset_password.py
+++ b/src/eduid_webapp/security/tests/test_reset_password.py
@@ -188,6 +188,76 @@ class SecurityResetPasswordTests(EduidAPITestCase):
         self.assertEqual(self.app.proofing_log.db_count(), 1)
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    def test_password_reset_email_code_magic(self, mock_sendmail):
+        mock_sendmail.return_value = True
+
+        self.app.config.environment = 'staging'
+        self.app.config.magic_code = 'magic-code'
+        with self.app.test_client() as c:
+            c.get('/reset-password/')
+            with c.session_transaction() as sess:
+                data = {
+                    'csrf': sess.get_csrf_token(),
+                    'email': 'johnsmith@example.com'
+                }
+            response = c.post('/reset-password/', data=data)
+            self.assertEqual(response.status_code, 200)
+
+            response = c.get('/reset-password/email/magic-code')
+
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            self.assertIsNotNone(state)
+            self.assertEqual(state.email_code.is_verified, True)
+            self.assertEqual(self.app.proofing_log.db_count(), 1)
+
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.location, 'http://{}/reset-password/extra-security/{}'.format(
+                             self.app.config.server_name, state.email_code.code))
+            self.assertEqual(self.app.proofing_log.db_count(), 1)
+
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    def test_password_reset_email_code_wrong_magic(self, mock_sendmail):
+        mock_sendmail.return_value = True
+
+        self.app.config.environment = 'staging'
+        self.app.config.magic_code = 'magic-code'
+        with self.app.test_client() as c:
+            c.get('/reset-password/')
+            with c.session_transaction() as sess:
+                data = {
+                    'csrf': sess.get_csrf_token(),
+                    'email': 'johnsmith@example.com'
+                }
+            response = c.post('/reset-password/', data=data)
+            self.assertEqual(response.status_code, 200)
+
+            response = c.get('/reset-password/email/wrong-magic-code')
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(b'The requested state can not be found' in response.data)
+
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    def test_password_reset_email_code_magic_pro(self, mock_sendmail):
+        mock_sendmail.return_value = True
+
+        self.app.config.environment = 'pro'
+        self.app.config.magic_code = 'magic-code'
+        with self.app.test_client() as c:
+            c.get('/reset-password/')
+            with c.session_transaction() as sess:
+                data = {
+                    'csrf': sess.get_csrf_token(),
+                    'email': 'johnsmith@example.com'
+                }
+            response = c.post('/reset-password/', data=data)
+            self.assertEqual(response.status_code, 200)
+
+            response = c.get('/reset-password/email/magic-code')
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(b'The requested state can not be found' in response.data)
+
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_password_reset_email_code_mail_relay_problem(self, mock_sendmail):
         mock_sendmail.side_effect = MailTaskFailed('test')
         response = self.post_email_address('johnsmith@example.com')
@@ -242,6 +312,63 @@ class SecurityResetPasswordTests(EduidAPITestCase):
 
         state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
         self.assertEqual(state.phone_code.is_verified, True)
+
+    @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
+    @patch('eduid_common.api.msg.MsgRelay.sendsms')
+    def test_password_reset_extra_security_phone_with_magic_code(self, mock_sendmail, mock_sendsms):
+        mock_sendmail.return_value = True
+        mock_sendsms.return_value = True
+
+        self.app.config.environment = 'staging'
+        self.app.config.magic_code = 'magic-code'
+        email_address = 'johnsmith@example.com'
+
+        with self.app.test_client() as c:
+            c.get('/reset-password/')
+            with c.session_transaction() as sess:
+                data = {
+                    'csrf': sess.get_csrf_token(),
+                    'email': email_address
+                }
+            response = c.post('/reset-password/', data=data)
+            self.assertEqual(response.status_code, 200)
+
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            self.assertIsNotNone(state)
+
+            response = c.get('/reset-password/email/magic-code')
+
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.location, 'http://{}/reset-password/extra-security/{}'.format(
+                             self.app.config.server_name, state.email_code.code))
+            self.assertEqual(self.app.proofing_log.db_count(), 1)
+
+            c.get('/reset-password/extra-security/magic-code')
+            with c.session_transaction() as sess:
+                data = {
+                    'csrf': sess.get_csrf_token(),
+                    'phone_number_index': '0'
+                }
+            response = c.post('/reset-password/extra-security/magic-code', data=data)
+            self.assertEqual(response.status_code, 302)
+
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            self.assertIsNotNone(state.phone_code)
+            self.assertEqual(state.phone_code.is_verified, False)
+
+            c.get('/reset-password/extra-security/phone/magic-code')
+
+            with c.session_transaction() as sess:
+                data = {
+                    'csrf': sess.get_csrf_token(),
+                    'phone_code': 'magic-code'
+                }
+            response = c.post('/reset-password/extra-security/phone/magic-code', data=data)
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(self.app.proofing_log.db_count(), 2)
+
+            state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user_eppn)
+            self.assertEqual(state.phone_code.is_verified, True)
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     @patch('eduid_common.api.msg.MsgRelay.sendsms')

--- a/src/eduid_webapp/security/views/reset_password.py
+++ b/src/eduid_webapp/security/views/reset_password.py
@@ -221,7 +221,14 @@ def extra_security_phone_number(state):
         form = ResetPasswordVerifyPhoneNumberSchema().load(request.form)
         if not form.errors and session.get_csrf_token() == form.data['csrf']:
             current_app.logger.info('Trying to verify phone code')
-            if form.data.get('phone_code', '') == state.phone_code.code:
+
+            phone_code = form.data.get('phone_code', '')
+
+            if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
+                if phone_code == current_app.config.magic_code:
+                    phone_code = session['resetpw_sms_verification_code']
+
+            if phone_code == state.phone_code.code:
                 if not verify_phone_number(state):
                     current_app.logger.info('Could not validated phone code for {}'.format(state.eppn))
                     view_context = {

--- a/src/eduid_webapp/security/views/reset_password.py
+++ b/src/eduid_webapp/security/views/reset_password.py
@@ -33,6 +33,9 @@ def require_state(f):
         mail_expiration_time = current_app.config.email_code_timeout
         sms_expiration_time = current_app.config.phone_code_timeout
 
+        # Backdoor for the staging and dev environments where a magic code
+        # bypasses verification of the emailed code, to be used in automated integration tests.
+        # Here we retrieve the real code from the session.
         if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
             if email_code == current_app.config.magic_code:
                 email_code = session['resetpw_email_verification_code']
@@ -224,6 +227,9 @@ def extra_security_phone_number(state):
 
             phone_code = form.data.get('phone_code', '')
 
+            # Backdoor for the staging and dev environments where a magic code
+            # bypasses verification of the sms'd code, to be used in automated integration tests.
+            # Here we retrieve the real code from the session.
             if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
                 if phone_code == current_app.config.magic_code:
                     phone_code = session['resetpw_sms_verification_code']

--- a/src/eduid_webapp/security/views/reset_password.py
+++ b/src/eduid_webapp/security/views/reset_password.py
@@ -122,7 +122,7 @@ def email_reset_code(state):
         current_app.logger.info('Redirecting user to extra security view')
         return redirect(url_for('reset_password.choose_extra_security', email_code=state.email_code.code))
 
-    current_app.logger.info('Could not validated email code for {}'.format(state.eppn))
+    current_app.logger.info('Could not validate email code for {}'.format(state.eppn))
     view_context = {
         'heading': _('Temporary technical problem'),
         'text': _('Please try again.'),

--- a/src/eduid_webapp/security/views/reset_password.py
+++ b/src/eduid_webapp/security/views/reset_password.py
@@ -32,6 +32,11 @@ def require_state(f):
         email_code = kwargs.pop('email_code')
         mail_expiration_time = current_app.config.email_code_timeout
         sms_expiration_time = current_app.config.phone_code_timeout
+
+        if current_app.config.environment in ('staging', 'dev') and current_app.config.magic_code:
+            if email_code == current_app.config.magic_code:
+                email_code = session['resetpw_email_verification_code']
+
         try:
             state = current_app.password_reset_state_db.get_state_by_email_code(email_code)
             current_app.logger.debug(f'Found state using email_code {email_code}: {state}')


### PR DESCRIPTION
Magic code to bypass code verification for emailed and sms'ed verification codes while resetting the password.

To use, The security app needs the configuration key `environment` with a value of `'staging'` or `'dev'`, and the key `magic_code` with some value.