### PR TITLE
Eperez bypass captcha

### DIFF
--- a/src/eduid_webapp/signup/settings/common.py
+++ b/src/eduid_webapp/signup/settings/common.py
@@ -55,3 +55,4 @@ class SignupConfig(FlaskConfig):
     # Used to load the react bundle
     bundle_path: str = 'front-build/signup-bundle.dev.js'
     bundle_version: str = 'test'
+    magic_code: str = ''

--- a/src/eduid_webapp/signup/tests/test_app.py
+++ b/src/eduid_webapp/signup/tests/test_app.py
@@ -226,6 +226,12 @@ class SignupTests(EduidAPITestCase):
 
     def test_captcha_used(self):
         email = 'johnsmith+magic-code@example.com'
+        user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
+        user.mail_addresses.primary.email = email
+        self.app.central_userdb.save(user)
+        data = user.to_dict()
+        self.app.private_userdb.save(self.app.private_userdb.UserClass(data=data),
+                                     check_sync=False)
         with self.session_cookie(self.browser) as client:
             with client.session_transaction() as sess:
                 with self.app.test_request_context():
@@ -240,11 +246,9 @@ class SignupTests(EduidAPITestCase):
 
                 data = json.loads(response.data)
                 self.assertEqual(data['type'], 'POST_SIGNUP_TRYCAPTCHA_FAIL')
-                breakpoint()
                 self.assertEqual(data['payload']['next'], 'address-used')
 
     def test_captcha_no_email(self):
-        email = 'dummy+magic-code@example.com'
         with self.session_cookie(self.browser) as client:
             with client.session_transaction() as sess:
                 with self.app.test_request_context():

--- a/src/eduid_webapp/signup/tests/test_app.py
+++ b/src/eduid_webapp/signup/tests/test_app.py
@@ -127,6 +127,9 @@ class SignupTests(EduidAPITestCase):
             data = json.loads(response.data)
             self.assertEqual(data['error'], True)
             self.assertEqual(data['type'], 'POST_SIGNUP_TRYCAPTCHA_FAIL')
+            self.assertIn('email', data['payload']['error'])
+            self.assertIn('csrf_token', data['payload']['error'])
+            self.assertIn('recaptcha_response', data['payload']['error'])
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_captcha_new_magic_code(self, mock_sendmail):
@@ -264,6 +267,8 @@ class SignupTests(EduidAPITestCase):
 
                 data = json.loads(response.data)
                 self.assertEqual(data['type'], 'POST_SIGNUP_TRYCAPTCHA_FAIL')
+                self.assertIn('email', data['payload']['error'])
+                self.assertNotIn('recaptcha_response', data['payload']['error'])
 
     def test_captcha_no_tou(self):
         email = 'dummy+magic-code@example.com'
@@ -281,6 +286,7 @@ class SignupTests(EduidAPITestCase):
 
                 data = json.loads(response.data)
                 self.assertEqual(data['type'], 'POST_SIGNUP_TRYCAPTCHA_FAIL')
+                self.assertEqual(data['payload']['message'], 'signup.tou-not-accepted')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_resend_email(self, mock_sendmail):

--- a/src/eduid_webapp/signup/tests/test_app.py
+++ b/src/eduid_webapp/signup/tests/test_app.py
@@ -121,7 +121,6 @@ class SignupTests(EduidAPITestCase):
         yield client
 
     def test_captcha_no_data_fail(self):
-        email = 'dummy@example.com'
         with self.session_cookie(self.browser) as client:
             response = client.post('/trycaptcha')
             self.assertEqual(response.status_code, 200)
@@ -191,6 +190,7 @@ class SignupTests(EduidAPITestCase):
 
                 data = json.loads(response.data)
                 self.assertEqual(data['type'], 'POST_SIGNUP_TRYCAPTCHA_FAIL')
+                self.assertEqual(data['payload']['message'], 'signup.recaptcha-not-verified')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_captcha_resend(self, mock_sendmail):

--- a/src/eduid_webapp/signup/tests/test_app.py
+++ b/src/eduid_webapp/signup/tests/test_app.py
@@ -170,6 +170,7 @@ class SignupTests(EduidAPITestCase):
 
                 data = json.loads(response.data)
                 self.assertEqual(data['type'], 'POST_SIGNUP_TRYCAPTCHA_FAIL')
+                self.assertEqual(data['payload']['message'], 'signup.recaptcha-not-verified')
 
     @patch('eduid_common.api.mail_relay.MailRelay.sendmail')
     def test_captcha_new_magic_code_wrong(self, mock_sendmail):

--- a/src/eduid_webapp/signup/views.py
+++ b/src/eduid_webapp/signup/views.py
@@ -62,7 +62,7 @@ def trycaptcha(email, recaptcha_response, tou_accepted):
     # add a backdoor to bypass recaptcha checks for humanness,
     # to be used in testing environments for automated integration tests.
     if config.environment in ('staging', 'dev') and config.magic_code != '':
-        if "{config.magic_code}@" in email:
+        if f"{config.magic_code}@" in email:
             recaptcha_verified = True
 
     # common path with no backdoor


### PR DESCRIPTION
Add a backdoor to bypass captcha verification for integrated selenium tests for signup. When:

* `config.environment` is `"dev"` or `"staging"` and `config.magic_code` is not the empty string
* The email address used contains the value in `config.magic_code` right before the @ (e.g., when `config.magic_code == "magic-code"`, a magic email address would be `"john+magic-code@example.com"`)

Then sending wrong captcha data will  not result in a signup failure.