### PR TITLE
post_action: add marshalling/unmarshalling schemas

### DIFF
--- a/src/eduid_webapp/actions/actions/mfa.py
+++ b/src/eduid_webapp/actions/actions/mfa.py
@@ -138,7 +138,7 @@ class Plugin(ActionPlugin):
             if result is not None:
                 action.result = result
                 current_app.actions_db.update_action(action)
-                return result
+                return action.result
 
         elif 'authenticatorData' in req_json:
             # CTAP2/Webauthn

--- a/src/eduid_webapp/actions/schemas.py
+++ b/src/eduid_webapp/actions/schemas.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 SUNET
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the SUNET nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+from marshmallow import fields
+
+from eduid_common.api.schemas.base import EduidSchema, FluxStandardAction
+from eduid_common.api.schemas.csrf import CSRFRequestMixin, CSRFResponseMixin
+
+
+class PostActionRequestSchema(EduidSchema, CSRFRequestMixin):
+    class Meta:
+        unknown = None  # Ignore unknown data - actions load the request JSON individually
+
+
+class PostActionResponseSchema(FluxStandardAction):
+    class PostActionResponsePayload(EduidSchema, CSRFResponseMixin):
+        data = fields.Dict(default=None)  # TODO: remove this extra layer dict in the payload
+        errors = fields.Dict(default=None)
+        message = fields.Str(required=False)
+
+    payload = fields.Nested(PostActionResponsePayload)

--- a/src/eduid_webapp/actions/tests/test_app.py
+++ b/src/eduid_webapp/actions/tests/test_app.py
@@ -154,17 +154,22 @@ class ActionsTests(ActionsTestCase):
 
     def test_post_action(self):
         response = self._post_action()
+        self._check_api_response(response, status=200, type_='POST_ACTIONS_POST_ACTION_SUCCESS')
         data = response.json
         self.assertEqual(data['payload']['data']['completed'], 'done')
         self.assertEqual(data['type'], 'POST_ACTIONS_POST_ACTION_SUCCESS')
 
     def test_post_action_no_csrf(self):
         response = self._post_action(csrf_token='')
-        self.assertEqual(response.status_code, 400)
+        self._check_api_error(
+            response, type_='POST_ACTIONS_POST_ACTION_FAIL', error={'csrf_token': ['CSRF failed to validate'],},
+        )
 
     def test_post_action_wrong_csrf(self):
         response = self._post_action(csrf_token='wrong-token')
-        self.assertEqual(response.status_code, 400)
+        self._check_api_error(
+            response, type_='POST_ACTIONS_POST_ACTION_FAIL', error={'csrf_token': ['CSRF failed to validate'],},
+        )
 
     def test_post_action_action_error(self):
         response = self._post_action(action_error=True)

--- a/src/eduid_webapp/actions/tests/test_app.py
+++ b/src/eduid_webapp/actions/tests/test_app.py
@@ -155,9 +155,7 @@ class ActionsTests(ActionsTestCase):
     def test_post_action(self):
         response = self._post_action()
         self._check_api_response(response, status=200, type_='POST_ACTIONS_POST_ACTION_SUCCESS')
-        data = response.json
-        self.assertEqual(data['payload']['data']['completed'], 'done')
-        self.assertEqual(data['type'], 'POST_ACTIONS_POST_ACTION_SUCCESS')
+        self.assertEqual(response.json['payload']['data']['completed'], 'done')
 
     def test_post_action_no_csrf(self):
         response = self._post_action(csrf_token='')

--- a/src/eduid_webapp/actions/tests/test_mfa.py
+++ b/src/eduid_webapp/actions/tests/test_mfa.py
@@ -45,6 +45,7 @@ from eduid_userdb.credentials import U2F
 from eduid_userdb.fixtures.users import mocked_user_standard
 
 from eduid_webapp.actions.actions.mfa import Plugin
+from eduid_webapp.actions.helpers import ActionsMsg
 from eduid_webapp.actions.testing import ActionsTestCase, MockIdPContext
 
 __author__ = 'ft'
@@ -213,6 +214,7 @@ class MFAActionPluginTests(ActionsTestCase):
     def test_action_success(self):
         data1 = {'tokenResponse': 'dummy-response'}
         response = self._action(data1=data1)
+        self._check_api_result(response, type_='POST_ACTIONS_POST_ACTION_SUCCESS', msg=ActionsMsg.action_completed)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
         self.assertEqual(data['payload']['message'], "actions.action-completed")
@@ -239,7 +241,9 @@ class MFAActionPluginTests(ActionsTestCase):
             'csrf_token': 'wrong-token',
         }
         response = self._action(data1=data1)
-        self.assertEqual(response.status_code, 400)
+        self._check_api_error(
+            response, type_='POST_ACTIONS_POST_ACTION_FAIL', error={'csrf_token': ['CSRF failed to validate'],},
+        )
 
     @patch('eduid_common.authn.fido_tokens.complete_authentication')
     def test_action_webauthn_legacy_token(self, mock_complete_authn):

--- a/src/eduid_webapp/actions/views.py
+++ b/src/eduid_webapp/actions/views.py
@@ -38,8 +38,8 @@ import json
 from flask import Blueprint, abort, redirect, render_template, request, url_for
 from six.moves.urllib_parse import urlsplit, urlunsplit
 
-from eduid_common.api.decorators import MarshalWith
-from eduid_common.api.messages import CommonMsg, error_message, success_message
+from eduid_common.api.decorators import MarshalWith, UnmarshalWith
+from eduid_common.api.messages import CommonMsg, FluxData, error_message, success_message
 from eduid_common.api.schemas.base import FluxStandardAction
 from eduid_common.authn.utils import check_previous_identification
 from eduid_common.session import session
@@ -47,6 +47,7 @@ from eduid_userdb.actions import Action
 
 from eduid_webapp.actions.app import current_actions_app as current_app
 from eduid_webapp.actions.helpers import ActionsMsg, get_next_action
+from eduid_webapp.actions.schemas import PostActionRequestSchema, PostActionResponseSchema
 
 actions_views = Blueprint('actions', __name__, url_prefix='', template_folder='templates')
 
@@ -115,14 +116,10 @@ def get_actions():
 
 
 @actions_views.route('/post-action', methods=['POST'])
-@MarshalWith(FluxStandardAction)
-def post_action():
-    if not request.data or session.get_csrf_token() != json.loads(request.data)['csrf_token']:
-        abort(400)
-    ret = _do_action()
-    # Add a new csrf token as this is a POST request
-    ret['csrf_token'] = session.new_csrf_token()
-    return ret
+@MarshalWith(PostActionResponseSchema)
+@UnmarshalWith(PostActionRequestSchema)
+def post_action() -> FluxData:
+    return _do_action()
 
 
 @actions_views.route('/redirect-action', methods=['GET'])
@@ -136,7 +133,7 @@ def redirect_action():
     return redirect(return_url)
 
 
-def _do_action():
+def _do_action() -> FluxData:
     action_type = session.get('current_plugin')
     if not action_type:
         abort(403)
@@ -165,7 +162,7 @@ def _do_action():
         'Performed step {} for action {} for eppn {}'.format(action.action_type, session['current_step'], eppn)
     )
     session['current_step'] += 1
-    return {'data': data}
+    return success_message(message=None, data={'data': data})
 
 
 def _aborted(action, exc):

--- a/src/eduid_webapp/actions/views.py
+++ b/src/eduid_webapp/actions/views.py
@@ -44,7 +44,6 @@ from eduid_common.api.schemas.base import FluxStandardAction
 from eduid_common.authn.utils import check_previous_identification
 from eduid_common.session import session
 from eduid_userdb.actions import Action
-
 from eduid_webapp.actions.app import current_actions_app as current_app
 from eduid_webapp.actions.helpers import ActionsMsg, get_next_action
 from eduid_webapp.actions.schemas import PostActionRequestSchema, PostActionResponseSchema
@@ -118,7 +117,7 @@ def get_actions():
 @actions_views.route('/post-action', methods=['POST'])
 @MarshalWith(PostActionResponseSchema)
 @UnmarshalWith(PostActionRequestSchema)
-def post_action() -> FluxData:
+def post_action():
     return _do_action()
 
 

--- a/src/eduid_webapp/actions/views.py
+++ b/src/eduid_webapp/actions/views.py
@@ -39,7 +39,7 @@ from flask import Blueprint, abort, redirect, render_template, request, url_for
 from six.moves.urllib_parse import urlsplit, urlunsplit
 
 from eduid_common.api.decorators import MarshalWith, UnmarshalWith
-from eduid_common.api.messages import CommonMsg, FluxData, error_message, success_message
+from eduid_common.api.messages import CommonMsg, error_message, success_message
 from eduid_common.api.schemas.base import FluxStandardAction
 from eduid_common.authn.utils import check_previous_identification
 from eduid_common.session import session
@@ -132,7 +132,7 @@ def redirect_action():
     return redirect(return_url)
 
 
-def _do_action() -> FluxData:
+def _do_action():
     action_type = session.get('current_plugin')
     if not action_type:
         abort(403)


### PR DESCRIPTION
This makes the actions app perform CSRF validation in the same manner as
all the other webapps.