### PR TITLE
Eperez elem init 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 eduid-userdb>=0.5.0
-eduid-common[webapp]>=0.7.9,==0.7.*
+eduid-common[webapp]>=0.7.11,==0.7.*
 eduid-am>=0.7.8
 eduid-msg>=0.10.9
 eduid_lookup_mobile>=0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-eduid-userdb>=0.4.18
-eduid-common[webapp]>=0.7.4,==0.7.*
-eduid-am>=0.7.7
+eduid-userdb>=0.5.0
+eduid-common[webapp]>=0.7.9,==0.7.*
+eduid-am>=0.7.8
 eduid-msg>=0.10.9
 eduid_lookup_mobile>=0.1.2
 eduid_scimapi==0.3.*

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,7 +4,7 @@ pynacl>=1.0.1
 python-etcd>=0.4.3
 Pillow>=3.0.0
 eduid-userdb>=0.5.0
-eduid-common[webapp]>=0.7.9,==0.7.*
+eduid-common[webapp]>=0.7.11,==0.7.*
 eduid-am>=0.7.8
 eduid-msg>=0.10.3b7
 marshmallow>=3.0,==3.*

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,9 +3,9 @@ redis>=3.2.0,==3.*
 pynacl>=1.0.1
 python-etcd>=0.4.3
 Pillow>=3.0.0
-eduid-userdb>=0.4.18
-eduid-common[webapp]>=0.7.4,==0.7.*
-eduid-am>=0.7.7
+eduid-userdb>=0.5.0
+eduid-common[webapp]>=0.7.9,==0.7.*
+eduid-am>=0.7.8
 eduid-msg>=0.10.3b7
 marshmallow>=3.0,==3.*
 marshmallow-enum==1.5.*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.2.16'
+version = '0.2.17'
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/snyk-test-requirements/requirements.txt
+++ b/snyk-test-requirements/requirements.txt
@@ -2,11 +2,11 @@
 blinker
 coverage==3.6
 cryptography>=2.0.3
-eduid-am>=0.7.7
-eduid-common>=0.7.4,==0.7.*
+eduid-am>=0.7.8
+eduid-common>=0.7.9,==0.7.*
 eduid_lookup_mobile>=0.0.6b3
 eduid-msg>=0.10.3b0
-eduid-userdb>=0.4.18
+eduid-userdb>=0.5.0
 eduid_scimapi==0.3.*
 Flask>=1.1,<1.2
 flask-babel>=0.11.1

--- a/snyk-test-requirements/requirements.txt
+++ b/snyk-test-requirements/requirements.txt
@@ -3,7 +3,7 @@ blinker
 coverage==3.6
 cryptography>=2.0.3
 eduid-am>=0.7.8
-eduid-common>=0.7.9,==0.7.*
+eduid-common>=0.7.11,==0.7.*
 eduid_lookup_mobile>=0.0.6b3
 eduid-msg>=0.10.3b0
 eduid-userdb>=0.5.0

--- a/src/eduid_webapp/actions/tests/test_tou.py
+++ b/src/eduid_webapp/actions/tests/test_tou.py
@@ -195,7 +195,8 @@ class ToUActionPluginTests(ActionsTestCase):
 
         user = self.app.central_userdb.get_user_by_eppn(self.user.eppn)
         four_years = timedelta(days=1460)
-        self.tou_accepted(user, TOU_ACTION['params']['version'], created_ts=datetime.utcnow() - four_years)
+        four_years_ago = datetime.utcnow() - four_years
+        self.tou_accepted(user, TOU_ACTION['params']['version'], created_ts=four_years_ago, modified_ts=four_years_ago)
         user = self.app.central_userdb.get_user_by_eppn(self.user.eppn)
 
         self.assertFalse(

--- a/src/eduid_webapp/eidas/acs_actions.py
+++ b/src/eduid_webapp/eidas/acs_actions.py
@@ -71,12 +71,12 @@ def token_verify_action(session_info: Mapping[str, Any], user: User) -> Werkzeug
         )
 
     # Check that a verified NIN is equal to the asserted attribute personalIdentityNumber
-    asserted_nin_in_list = get_saml_attribute(session_info, 'personalIdentityNumber')
+    _nin_list = get_saml_attribute(session_info, 'personalIdentityNumber')
 
-    if asserted_nin_in_list is None:
+    if _nin_list is None:
         raise ValueError("Missing PIN in SAML session info")
 
-    asserted_nin = asserted_nin_in_list[0]
+    asserted_nin = _nin_list[0]
     user_nin = proofing_user.nins.verified.find(asserted_nin)
     if not user_nin:
         current_app.logger.error('Asserted NIN not matching user verified nins')
@@ -145,12 +145,12 @@ def nin_verify_action(session_info: Mapping[str, Any], user: User) -> WerkzeugRe
         return redirect_with_msg(redirect_url, EidasMsg.reauthn_expired)
 
     proofing_user = ProofingUser.from_user(user, current_app.private_userdb)
-    asserted_nin_in_list = get_saml_attribute(session_info, 'personalIdentityNumber')
+    _nin_list = get_saml_attribute(session_info, 'personalIdentityNumber')
 
-    if asserted_nin_in_list is None:
+    if _nin_list is None:
         raise ValueError("Missing PIN in SAML session info")
 
-    asserted_nin = asserted_nin_in_list[0]
+    asserted_nin = _nin_list[0]
 
     if proofing_user.nins.verified.count != 0:
         current_app.logger.error('User already has a verified NIN')

--- a/src/eduid_webapp/eidas/acs_actions.py
+++ b/src/eduid_webapp/eidas/acs_actions.py
@@ -310,8 +310,9 @@ def mfa_authentication_action(session_info: Mapping[str, Any], user: User) -> We
 
     # Redirect back to action app but to the redirect-action view
     resp = redirect_with_msg(redirect_url, EidasMsg.action_completed, error=False)
-    scheme, netloc, path, query_string, fragment = urlsplit(resp.location)
-    new_path = urlappend(str(path), 'redirect-action')
-    new_url = urlunsplit((scheme, netloc, new_path, query_string, fragment))
+    parsed_url = urlsplit(str(resp.location))
+    new_path = urlappend(str(parsed_url.path), 'redirect-action')
+    parsed_url._replace(path=new_path)
+    new_url = urlunsplit(parsed_url)
     current_app.logger.debug(f'Redirecting to: {new_url}')
     return redirect(new_url)

--- a/src/eduid_webapp/eidas/acs_actions.py
+++ b/src/eduid_webapp/eidas/acs_actions.py
@@ -312,7 +312,7 @@ def mfa_authentication_action(session_info: Mapping[str, Any], user: User) -> We
     resp = redirect_with_msg(redirect_url, EidasMsg.action_completed, error=False)
     parsed_url = urlsplit(str(resp.location))
     new_path = urlappend(str(parsed_url.path), 'redirect-action')
-    parsed_url._replace(path=new_path)
+    parsed_url = parsed_url._replace(path=new_path)
     new_url = urlunsplit(parsed_url)
     current_app.logger.debug(f'Redirecting to: {new_url}')
     return redirect(new_url)

--- a/src/eduid_webapp/eidas/acs_actions.py
+++ b/src/eduid_webapp/eidas/acs_actions.py
@@ -90,7 +90,7 @@ def token_verify_action(session_info: Mapping[str, Any], user: User) -> Werkzeug
         current_app.stats.count('navet_error')
         return redirect_with_msg(redirect_url, CommonMsg.navet_error)
     proofing_log_entry = MFATokenProofing(
-        user=proofing_user,
+        eppn=proofing_user.eppn,
         created_by='eduid-eidas',
         nin=user_nin.number,
         issuer=issuer,
@@ -160,7 +160,7 @@ def nin_verify_action(session_info: Mapping[str, Any], user: User) -> WerkzeugRe
         return redirect_with_msg(redirect_url, CommonMsg.navet_error)
 
     proofing_log_entry = SwedenConnectProofing(
-        user=proofing_user,
+        eppn=proofing_user.eppn,
         created_by='eduid-eidas',
         nin=asserted_nin,
         issuer=issuer,
@@ -217,7 +217,7 @@ def nin_verify_BACKDOOR(user: User) -> WerkzeugResponse:
     }
 
     proofing_log_entry = SwedenConnectProofing(
-        user=proofing_user,
+        eppn=proofing_user.eppn,
         created_by='eduid-eidas',
         nin=asserted_nin,
         issuer=issuer,

--- a/src/eduid_webapp/email/verifications.py
+++ b/src/eduid_webapp/email/verifications.py
@@ -122,7 +122,7 @@ def verify_mail_address(state, proofing_user):
             proofing_user.mail_addresses.find(state.verification.email).is_primary = True
 
     mail_address_proofing = MailAddressProofing(
-        proofing_user,
+        eppn=proofing_user.eppn,
         created_by='email',
         mail_address=new_email.email,
         reference=state.reference,

--- a/src/eduid_webapp/letter_proofing/helpers.py
+++ b/src/eduid_webapp/letter_proofing/helpers.py
@@ -116,7 +116,7 @@ def create_proofing_state(eppn: str, nin: str) -> LetterProofingState:
         verification_code=get_short_hash(),
     )
     proofing_letter = SentLetterElement()
-    return LetterProofingState(eppn=eppn, nin=_nin, proofing_letter=proofing_letter)
+    return LetterProofingState(eppn=eppn, nin=_nin, proofing_letter=proofing_letter, id=None, modified_ts=None)
 
 
 def get_address(user: User, proofing_state: LetterProofingState) -> Optional[dict]:

--- a/src/eduid_webapp/letter_proofing/helpers.py
+++ b/src/eduid_webapp/letter_proofing/helpers.py
@@ -109,17 +109,14 @@ def check_state(state: LetterProofingState) -> StateExpireInfo:
 
 
 def create_proofing_state(eppn: str, nin: str) -> LetterProofingState:
-    _nin = NinProofingElement.from_dict(
-        dict(
-            number=nin,
-            created_by='eduid-idproofing-letter',
-            created_ts=True,
-            verified=False,
-            verification_code=get_short_hash(),
-        )
+    _nin = NinProofingElement(
+        number=nin,
+        created_by='eduid-idproofing-letter',
+        verified=False,
+        verification_code=get_short_hash(),
     )
-    proofing_letter = SentLetterElement.from_dict({})
-    return LetterProofingState(id=None, modified_ts=None, eppn=eppn, nin=_nin, proofing_letter=proofing_letter)
+    proofing_letter = SentLetterElement()
+    return LetterProofingState(eppn=eppn, nin=_nin, proofing_letter=proofing_letter)
 
 
 def get_address(user: User, proofing_state: LetterProofingState) -> Optional[dict]:

--- a/src/eduid_webapp/letter_proofing/helpers.py
+++ b/src/eduid_webapp/letter_proofing/helpers.py
@@ -112,7 +112,7 @@ def create_proofing_state(eppn: str, nin: str) -> LetterProofingState:
     _nin = NinProofingElement(
         number=nin,
         created_by='eduid-idproofing-letter',
-        verified=False,
+        is_verified=False,
         verification_code=get_short_hash(),
     )
     proofing_letter = SentLetterElement()

--- a/src/eduid_webapp/letter_proofing/helpers.py
+++ b/src/eduid_webapp/letter_proofing/helpers.py
@@ -114,10 +114,7 @@ def check_state(state: LetterProofingState) -> StateExpireInfo:
 
 def create_proofing_state(eppn: str, nin: str) -> LetterProofingState:
     _nin = NinProofingElement(
-        number=nin,
-        created_by='eduid-idproofing-letter',
-        is_verified=False,
-        verification_code=get_short_hash(),
+        number=nin, created_by='eduid-idproofing-letter', is_verified=False, verification_code=get_short_hash(),
     )
     proofing_letter = SentLetterElement()
     return LetterProofingState(eppn=eppn, nin=_nin, proofing_letter=proofing_letter, id=None, modified_ts=None)

--- a/src/eduid_webapp/letter_proofing/tests/test_app.py
+++ b/src/eduid_webapp/letter_proofing/tests/test_app.py
@@ -404,7 +404,7 @@ class LetterProofingTests(EduidAPITestCase):
 
         # User with locked_identity and correct nin
         user.locked_identity.add(
-            LockedIdentityNin.from_dict(dict(number=self.test_user_nin, created_by='test', created_ts=True))
+            LockedIdentityNin(number=self.test_user_nin, created_by='test')
         )
         self.app.central_userdb.save(user, check_sync=False)
         with self.session_cookie(self.browser, self.test_user_eppn):
@@ -418,7 +418,7 @@ class LetterProofingTests(EduidAPITestCase):
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         user.locked_identity.add(
-            LockedIdentityNin.from_dict(dict(number=self.test_user_nin, created_by='test', created_ts=True))
+            LockedIdentityNin(number=self.test_user_nin, created_by='test')
         )
         self.app.central_userdb.save(user, check_sync=False)
 

--- a/src/eduid_webapp/letter_proofing/tests/test_app.py
+++ b/src/eduid_webapp/letter_proofing/tests/test_app.py
@@ -294,7 +294,6 @@ class LetterProofingTests(EduidAPITestCase):
         response = self.send_letter(self.test_user_nin)
         # move the proofing state back in time so that it is expired by now
         proofing_state = self.app.proofing_statedb.get_state_by_eppn(self.test_user_eppn)
-        proofing_state.proofing_letter._data['sent_ts'] = None
         proofing_state.proofing_letter.sent_ts = datetime.fromisoformat('2020-01-01T01:02:03')
         self.app.proofing_statedb.save(proofing_state)
 

--- a/src/eduid_webapp/letter_proofing/tests/test_app.py
+++ b/src/eduid_webapp/letter_proofing/tests/test_app.py
@@ -402,9 +402,7 @@ class LetterProofingTests(EduidAPITestCase):
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         # User with locked_identity and correct nin
-        user.locked_identity.add(
-            LockedIdentityNin(number=self.test_user_nin, created_by='test')
-        )
+        user.locked_identity.add(LockedIdentityNin(number=self.test_user_nin, created_by='test'))
         self.app.central_userdb.save(user, check_sync=False)
         with self.session_cookie(self.browser, self.test_user_eppn):
             response = self.send_letter(self.test_user_nin)
@@ -416,9 +414,7 @@ class LetterProofingTests(EduidAPITestCase):
         mock_request_user_sync.side_effect = self.request_user_sync
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
-        user.locked_identity.add(
-            LockedIdentityNin(number=self.test_user_nin, created_by='test')
-        )
+        user.locked_identity.add(LockedIdentityNin(number=self.test_user_nin, created_by='test'))
         self.app.central_userdb.save(user, check_sync=False)
 
         # User with locked_identity and incorrect nin

--- a/src/eduid_webapp/letter_proofing/views.py
+++ b/src/eduid_webapp/letter_proofing/views.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+from datetime import datetime
+
 from flask import Blueprint, abort
 
 from eduid_common.api.decorators import MarshalWith, UnmarshalWith, can_verify_identity, require_user
@@ -97,7 +99,7 @@ def proofing(user: User, nin: str) -> FluxData:
     # Save the users proofing state
     proofing_state.proofing_letter.transaction_id = campaign_id
     proofing_state.proofing_letter.is_sent = True
-    proofing_state.proofing_letter.sent_ts = True
+    proofing_state.proofing_letter.sent_ts = datetime.utcnow()
     current_app.proofing_statedb.save(proofing_state)
     result = check_state(proofing_state)
     result.message = LetterMsg.letter_sent
@@ -139,7 +141,7 @@ def verify_code(user: User, code: str) -> FluxData:
         return error_response(message=CommonMsg.navet_error)
 
     proofing_log_entry = LetterProofing(
-        user,
+        eppn=user.eppn,
         created_by='eduid_letter_proofing',
         nin=proofing_state.nin.number,
         letter_sent_to=proofing_state.proofing_letter.address,

--- a/src/eduid_webapp/lookup_mobile_proofing/helpers.py
+++ b/src/eduid_webapp/lookup_mobile_proofing/helpers.py
@@ -92,7 +92,7 @@ def match_mobile_to_user(user, self_asserted_nin, verified_mobile_numbers):
             'OfficialAddress': {'Address2': 'Dummy address', 'City': 'LANDET', 'PostalCode': '12345'},
         }
         proofing_log_entry = TeleAdressProofing(
-            proofing_user,
+            eppn=proofing_user.eppn,
             created_by='lookup_mobile_proofing',
             reason='magic_cookie',
             nin=self_asserted_nin,
@@ -123,7 +123,7 @@ def match_mobile_to_user(user, self_asserted_nin, verified_mobile_numbers):
             current_app.logger.info('Looking up official address for user {}.'.format(proofing_user))
             user_postal_address = current_app.msg_relay.get_postal_address(self_asserted_nin)
             proofing_log_entry = TeleAdressProofing(
-                proofing_user,
+                eppn=proofing_user.eppn,
                 created_by='lookup_mobile_proofing',
                 reason='matched',
                 nin=self_asserted_nin,
@@ -153,7 +153,7 @@ def match_mobile_to_user(user, self_asserted_nin, verified_mobile_numbers):
                 current_app.logger.info('Looking up official address for relation {}.'.format(proofing_user))
                 registered_postal_address = current_app.msg_relay.get_postal_address(registered_to_nin)
                 proofing_log_entry = TeleAdressProofingRelation(
-                    proofing_user,
+                    eppn=proofing_user.eppn,
                     created_by='lookup_mobile_proofing',
                     reason='match_by_navet',
                     nin=self_asserted_nin,

--- a/src/eduid_webapp/oidc_proofing/helpers.py
+++ b/src/eduid_webapp/oidc_proofing/helpers.py
@@ -183,9 +183,14 @@ def handle_seleg_userinfo(user: ProofingUser, proofing_state: OidcProofingState,
         address = current_app.msg_relay.get_postal_address(proofing_state.nin.number, timeout=15)
         # Transaction id is the same data as used for the QR code
         transaction_id = metadata['opaque']
+
+        created_by = proofing_state.nin.created_by
+        if created_by is None:
+            created_by = 'se-leg'
+
         proofing_log_entry = SeLegProofing(
             eppn=user.eppn,
-            created_by=proofing_state.nin.created_by,
+            created_by=created_by,
             nin=proofing_state.nin.number,
             vetting_by='se-leg',
             transaction_id=transaction_id,

--- a/src/eduid_webapp/oidc_proofing/helpers.py
+++ b/src/eduid_webapp/oidc_proofing/helpers.py
@@ -184,7 +184,7 @@ def handle_seleg_userinfo(user: ProofingUser, proofing_state: OidcProofingState,
         # Transaction id is the same data as used for the QR code
         transaction_id = metadata['opaque']
         proofing_log_entry = SeLegProofing(
-            user,
+            eppn=user.eppn,
             created_by=proofing_state.nin.created_by,
             nin=proofing_state.nin.number,
             vetting_by='se-leg',
@@ -229,7 +229,7 @@ def handle_freja_eid_userinfo(user, proofing_state, userinfo):
     # Lookup official address via Navet
     address = current_app.msg_relay.get_postal_address(proofing_state.nin.number, timeout=15)
     proofing_log_entry = SeLegProofingFrejaEid(
-        user,
+        eppn=user.eppn,
         created_by=proofing_state.nin.created_by,
         nin=proofing_state.nin.number,
         transaction_id=transaction_id,

--- a/src/eduid_webapp/oidc_proofing/tests/test_app.py
+++ b/src/eduid_webapp/oidc_proofing/tests/test_app.py
@@ -569,9 +569,7 @@ class OidcProofingTests(EduidAPITestCase):
         csrf_token = response['payload']['csrf_token']
 
         # User with locked_identity and correct nin
-        user.locked_identity.add(
-            LockedIdentityNin(number=self.test_user_nin, created_by='test')
-        )
+        user.locked_identity.add(LockedIdentityNin(number=self.test_user_nin, created_by='test'))
         self.app.central_userdb.save(user, check_sync=False)
 
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:
@@ -610,9 +608,7 @@ class OidcProofingTests(EduidAPITestCase):
 
         csrf_token = response['payload']['csrf_token']
 
-        user.locked_identity.add(
-            LockedIdentityNin(number=self.test_user_nin, created_by='test')
-        )
+        user.locked_identity.add(LockedIdentityNin(number=self.test_user_nin, created_by='test'))
         self.app.central_userdb.save(user, check_sync=False)
 
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:

--- a/src/eduid_webapp/oidc_proofing/tests/test_app.py
+++ b/src/eduid_webapp/oidc_proofing/tests/test_app.py
@@ -570,7 +570,7 @@ class OidcProofingTests(EduidAPITestCase):
 
         # User with locked_identity and correct nin
         user.locked_identity.add(
-            LockedIdentityNin.from_dict(dict(number=self.test_user_nin, created_by='test', created_ts=True))
+            LockedIdentityNin(number=self.test_user_nin, created_by='test')
         )
         self.app.central_userdb.save(user, check_sync=False)
 
@@ -611,7 +611,7 @@ class OidcProofingTests(EduidAPITestCase):
         csrf_token = response['payload']['csrf_token']
 
         user.locked_identity.add(
-            LockedIdentityNin.from_dict(dict(number=self.test_user_nin, created_by='test', created_ts=True))
+            LockedIdentityNin(number=self.test_user_nin, created_by='test')
         )
         self.app.central_userdb.save(user, check_sync=False)
 

--- a/src/eduid_webapp/orcid/tests/test_app.py
+++ b/src/eduid_webapp/orcid/tests/test_app.py
@@ -173,7 +173,6 @@ class OrcidTests(EduidAPITestCase):
         response = json.loads(response.data)
         self.assertEqual(response['type'], 'GET_ORCID_SUCCESS')
         self.assertEqual(response['payload']['orcid']['id'], self.orcid_element.id)
-        self.assertEqual(response['payload']['orcid']['name'], self.orcid_element.name)
         self.assertEqual(response['payload']['orcid']['given_name'], self.orcid_element.given_name)
         self.assertEqual(response['payload']['orcid']['family_name'], self.orcid_element.family_name)
 

--- a/src/eduid_webapp/orcid/views.py
+++ b/src/eduid_webapp/orcid/views.py
@@ -151,7 +151,7 @@ def authorization_response(user):
         )
     )
     orcid_proofing = OrcidProofing(
-        proofing_user,
+        eppn=proofing_user.eppn,
         created_by='orcid',
         orcid=orcid_element.id,
         issuer=orcid_element.oidc_authz.id_token.iss,

--- a/src/eduid_webapp/phone/verifications.py
+++ b/src/eduid_webapp/phone/verifications.py
@@ -101,7 +101,7 @@ def verify_phone_number(state, proofing_user):
             proofing_user.phone_numbers.find(number).is_primary = True
 
     phone_number_proofing = PhoneNumberProofing(
-        proofing_user,
+        eppn=proofing_user.eppn,
         created_by='phone',
         phone_number=state.verification.number,
         reference=state.reference,

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -350,7 +350,7 @@ def verify_email_address(state: ResetPasswordEmailState) -> bool:
         return False
 
     proofing_element = MailAddressProofing(
-        user,
+        eppn=user.eppn,
         created_by='security',
         mail_address=state.email_address,
         reference=state.reference,

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -410,7 +410,7 @@ def verify_phone_number(state: ResetPasswordEmailAndPhoneState) -> bool:
         return False
 
     proofing_element = PhoneNumberProofing(
-        user,
+        eppn=user.eppn,
         created_by='security',
         phone_number=state.phone_number,
         reference=state.reference,

--- a/src/eduid_webapp/security/helpers.py
+++ b/src/eduid_webapp/security/helpers.py
@@ -236,7 +236,7 @@ def verify_email_address(state):
         return False
 
     proofing_element = MailAddressProofing(
-        user,
+        eppn=user.eppn,
         created_by='security',
         mail_address=state.email_address,
         reference=state.reference,

--- a/src/eduid_webapp/security/helpers.py
+++ b/src/eduid_webapp/security/helpers.py
@@ -280,7 +280,7 @@ def verify_phone_number(state):
         return False
 
     proofing_element = PhoneNumberProofing(
-        user,
+        eppn=user.eppn,
         created_by='security',
         phone_number=state.phone_number,
         reference=state.reference,

--- a/src/eduid_webapp/security/tests/test_reset_password.py
+++ b/src/eduid_webapp/security/tests/test_reset_password.py
@@ -312,7 +312,6 @@ class SecurityResetPasswordTests(EduidAPITestCase):
         state = self.app.password_reset_state_db.get_state_by_email_code(state.email_code.code)
         self.app.logger.info('Moving phone-expire-state back in time')
         # Move state back in time so that the code will be expired
-        state.phone_code._data['created_ts'] = None
         state.phone_code.created_ts = datetime.datetime.fromtimestamp(123)
         self.app.password_reset_state_db.save(state)
         self.app.logger.info(f'Saved expired state: {state}')

--- a/src/eduid_webapp/security/tests/test_u2f.py
+++ b/src/eduid_webapp/security/tests/test_u2f.py
@@ -40,17 +40,14 @@ class SecurityU2FTests(EduidAPITestCase):
 
     def add_token_to_user(self, eppn):
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        u2f_token = U2F.from_dict(
-            dict(
-                version='version',
-                keyhandle='keyHandle',
-                app_id='appId',
-                public_key='publicKey',
-                attest_cert='cert',
-                description='description',
-                created_ts=True,
-                created_by='eduid_security',
-            )
+        u2f_token = U2F(
+            version='version',
+            keyhandle='keyHandle',
+            app_id='appId',
+            public_key='publicKey',
+            attest_cert='cert',
+            description='description',
+            created_by='eduid_security',
         )
         user.credentials.add(u2f_token)
         self.app.central_userdb.save(user)

--- a/src/eduid_webapp/security/tests/test_webauthn.py
+++ b/src/eduid_webapp/security/tests/test_webauthn.py
@@ -186,17 +186,14 @@ class SecurityWebauthnTests(EduidAPITestCase):
 
     def _add_u2f_token_to_user(self, eppn):
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        u2f_token = U2F.from_dict(
-            dict(
-                version='version',
-                keyhandle='keyHandle',
-                app_id='appId',
-                public_key='publicKey',
-                attest_cert='cert',
-                description='description',
-                created_by='eduid_security',
-                created_ts=True,
-            )
+        u2f_token = U2F(
+            version='version',
+            keyhandle='keyHandle',
+            app_id='appId',
+            public_key='publicKey',
+            attest_cert='cert',
+            description='description',
+            created_by='eduid_security',
         )
         user.credentials.add(u2f_token)
         self.app.central_userdb.save(user)

--- a/src/eduid_webapp/security/views/u2f.py
+++ b/src/eduid_webapp/security/views/u2f.py
@@ -78,17 +78,14 @@ def bind(user, version, registration_data, client_data, description=''):
     if not isinstance(pem_cert, six.string_types):
         pem_cert = pem_cert.decode('utf-8')
 
-    u2f_token = U2F.from_dict(
-        dict(
-            version=device['version'],
-            keyhandle=device['keyHandle'],
-            app_id=device['appId'],
-            public_key=device['publicKey'],
-            attest_cert=pem_cert,
-            description=description,
-            created_by='eduid_security',
-            created_ts=True,
-        )
+    u2f_token = U2F(
+        version=device['version'],
+        keyhandle=device['keyHandle'],
+        app_id=device['appId'],
+        public_key=device['publicKey'],
+        attest_cert=pem_cert,
+        description=description,
+        created_by='eduid_security',
     )
     security_user.credentials.add(u2f_token)
     save_and_sync_user(security_user)

--- a/src/eduid_webapp/signup/verifications.py
+++ b/src/eduid_webapp/signup/verifications.py
@@ -187,7 +187,7 @@ def verify_email_code(code):
         raise AlreadyVerifiedException()
 
     mail_dict = signup_user.pending_mail_address.to_dict()
-    mail_address = MailAddress.from_dict(mail_dict, raise_on_unknown=False)
+    mail_address = MailAddress.from_dict(mail_dict)
     if mail_address.is_verified:
         # There really should be no way to get here, is_verified is set to False when
         # the EmailProofingElement is created.
@@ -195,7 +195,7 @@ def verify_email_code(code):
         raise AlreadyVerifiedException()
 
     mail_address_proofing = MailAddressProofing(
-        signup_user,
+        eppn=signup_user.eppn,
         created_by='signup',
         mail_address=mail_address.email,
         reference=signup_user.proofing_reference,


### PR DESCRIPTION
Moving Element and subclasses to dataclasses
* State constructors now accept an eppn rather than a user
* Use constructors rather than `from_dict(dict(...))`
* Initialize timestamps with datetime instead of with boolean
* Fix typing issues