### PR TITLE
Eperez state init 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eduid-userdb>=0.6.1
+eduid-userdb>=0.6.3
 eduid-common[webapp]>=0.8.0,==0.8.*
 eduid-am>=0.7.9
 eduid-msg>=0.10.9

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,7 +3,7 @@ redis>=3.2.0,==3.*
 pynacl>=1.0.1
 python-etcd>=0.4.3
 Pillow>=3.0.0
-eduid-userdb>=0.6.1
+eduid-userdb>=0.6.3
 eduid-common[webapp]>=0.8.0,==0.8.*
 eduid-am>=0.7.9
 eduid-msg>=0.10.3b7

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.2.19'
+version = '0.2.20'
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/snyk-test-requirements/requirements.txt
+++ b/snyk-test-requirements/requirements.txt
@@ -6,7 +6,7 @@ eduid-am>=0.7.9
 eduid-common>=0.8.0,==0.8.*
 eduid_lookup_mobile>=0.0.6b3
 eduid-msg>=0.10.3b0
-eduid-userdb>=0.6.1
+eduid-userdb>=0.6.3
 eduid_scimapi==0.3.*
 Flask>=1.1,<1.2
 flask-babel>=0.11.1

--- a/src/eduid_webapp/actions/actions/mfa.py
+++ b/src/eduid_webapp/actions/actions/mfa.py
@@ -60,12 +60,8 @@ class Plugin(ActionPlugin):
         app.config.mfa_testing = False
 
     def get_config_for_bundle(self, action):
-        if action.old_format:
-            userid = action.user_id
-            user = current_app.central_userdb.get_user_by_id(userid, raise_on_missing=False)
-        else:
-            eppn = action.eppn
-            user = current_app.central_userdb.get_user_by_eppn(eppn, raise_on_missing=False)
+        eppn = action.eppn
+        user = current_app.central_userdb.get_user_by_eppn(eppn, raise_on_missing=False)
         current_app.logger.debug('Loaded User {} from db'.format(user))
         if not user:
             raise self.ActionError(ActionsMsg.user_not_found)
@@ -94,12 +90,8 @@ class Plugin(ActionPlugin):
                 'testing': True,
             }
 
-        if action.old_format:
-            userid = action.user_id
-            user = current_app.central_userdb.get_user_by_id(userid, raise_on_missing=False)
-        else:
-            eppn = action.eppn
-            user = current_app.central_userdb.get_user_by_eppn(eppn, raise_on_missing=False)
+        eppn = action.eppn
+        user = current_app.central_userdb.get_user_by_eppn(eppn, raise_on_missing=False)
         current_app.logger.debug('Loaded User {} from db (in perform_action)'.format(user))
 
         # Third party service MFA

--- a/src/eduid_webapp/actions/views.py
+++ b/src/eduid_webapp/actions/views.py
@@ -85,7 +85,7 @@ def get_config():
     except KeyError:
         abort(403)
     plugin_obj = current_app.plugins[action_type]()
-    action = Action(data=session['current_action'])
+    action = Action.from_dict(session['current_action'])
     try:
         config = plugin_obj.get_config_for_bundle(action)
         config['csrf_token'] = session.new_csrf_token()
@@ -104,8 +104,7 @@ def get_actions():
         )
     action_type = session['current_plugin']
     plugin_obj = current_app.plugins[action_type]()
-    old_format = 'user_oid' in session['current_action']
-    action = Action(data=session['current_action'], old_format=old_format)
+    action = Action.from_dict(session['current_action'])
     current_app.logger.info('Starting pre-login action {} ' 'for user {}'.format(action.action_type, user))
     try:
         url = plugin_obj.get_url_for_bundle(action)
@@ -139,8 +138,7 @@ def _do_action():
         abort(403)
 
     plugin_obj = current_app.plugins[action_type]()
-    old_format = 'user_oid' in session['current_action']
-    action = Action(data=session['current_action'], old_format=old_format)
+    action = Action.from_dict(session['current_action'])
     try:
         data = plugin_obj.perform_step(action)
     except plugin_obj.ActionError as exc:

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -161,7 +161,7 @@ def get_pwreset_state(email_code: str) -> Union[ResetPasswordEmailState, ResetPa
         # Revert the state to EmailState to allow the user to choose extra security again
         current_app.password_reset_state_db.remove_state(state)
         state = ResetPasswordEmailState(
-            eppn=state.eppn, email_address=state.email_address, email_code=state.email_code.code
+            eppn=state.eppn, email_address=state.email_address, email_code=state.email_code
         )
         current_app.password_reset_state_db.save(state)
         raise BadCode(ResetPwMsg.expired_sms_code)

--- a/src/eduid_webapp/reset_password/helpers.py
+++ b/src/eduid_webapp/reset_password/helpers.py
@@ -160,9 +160,7 @@ def get_pwreset_state(email_code: str) -> Union[ResetPasswordEmailState, ResetPa
         current_app.logger.info(f'Phone code expired for state: {email_code}')
         # Revert the state to EmailState to allow the user to choose extra security again
         current_app.password_reset_state_db.remove_state(state)
-        state = ResetPasswordEmailState(
-            eppn=state.eppn, email_address=state.email_address, email_code=state.email_code
-        )
+        state = ResetPasswordEmailState(eppn=state.eppn, email_address=state.email_address, email_code=state.email_code)
         current_app.password_reset_state_db.save(state)
         raise BadCode(ResetPwMsg.expired_sms_code)
 

--- a/src/eduid_webapp/reset_password/views/reset_password.py
+++ b/src/eduid_webapp/reset_password/views/reset_password.py
@@ -364,6 +364,9 @@ def choose_extra_security_phone(code: str, phone_index: int) -> FluxData:
         current_app.logger.info(f'User with eppn {state.eppn} has not verified their email address')
         return error_response(message=ResetPwMsg.email_not_validated)
 
+    if state.extra_security is None:  # please mypy
+        raise ValueError(f'User {state.eppn} trying to reset password with extra security whithout alternatives')
+
     phone_number = state.extra_security['phone_numbers'][phone_index]
     current_app.logger.info(f'Trying to send password reset sms to user with eppn {state.eppn}')
     try:


### PR DESCRIPTION
Turn Action and State objects into dataclasses.

Things to note:

* Remove old_format param for initialization of Action objects
* Action constructor no longer accepts a data dict (use `from_dict` instead`)
