### PR TITLE
letter proofing backwards compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.2.24'
+version = '0.2.25'
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/eduid_webapp/letter_proofing/settings/common.py
+++ b/src/eduid_webapp/letter_proofing/settings/common.py
@@ -51,3 +51,6 @@ class LetterProofingConfig(FlaskConfig):
     ekopost_api_user: str = ''
     ekopost_api_pw: str = ''
     ekopost_debug_pdf: str = ''
+
+    # Remove expired states on GET /proofing if this is set to True
+    backwards_compat_remove_expired_state: bool = False

--- a/src/eduid_webapp/letter_proofing/views.py
+++ b/src/eduid_webapp/letter_proofing/views.py
@@ -33,6 +33,11 @@ def get_state(user) -> FluxData:
     if proofing_state:
         current_app.logger.info('Found proofing state for user {}'.format(user))
         result = check_state(proofing_state)
+        if result.is_expired and current_app.config.backwards_compat_remove_expired_state:
+            current_app.logger.info(f'Backwards-compat removing expired state for user {user}')
+            current_app.proofing_statedb.remove_state(proofing_state)
+            current_app.stats.count('letter_expired')
+            return success_response(message=LetterMsg.no_state)
         return result.to_response()
     return success_response(message=LetterMsg.no_state)
 


### PR DESCRIPTION
optionally remove expired states in GET /proofing

The change to not do it like this requires updates to the frontend code,
otherwise users can't recover once they have an expired state.